### PR TITLE
Add Wrapper for GNU ReadLine support

### DIFF
--- a/FAQ
+++ b/FAQ
@@ -117,18 +117,8 @@ then click on 'Implementations'.
 
 4.1: Clef does not work.  Is there an alternative?
 
-It is possible to use 'rlwrap' program (which is readline-based).
-The main FriCAS executable is designed to be run via line-editing
-wrapper program.  Normally for command line editing FriCAS uses
-clef.  However, it is possible to use different wrapper.
-To use 'rlwrap' do the following:
-
-1) Make a shell script to change calling convention, like:
-
-#!/bin/sh
-CFILE=$2
-shift 3
-exec /full/path/to/rlwrap -f $CFILE "$@"
+If you have GNU Readline and 'rlwrap' installed, the '-rl' option will
+use GNU Readline editing, tab completion, and history.
 
 2) Type
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -142,6 +142,7 @@ install-src:
 	fi
 	echo export FRICAS >> '${COMMAND}'.tmp
 
+	$(INSTALL_SCRIPT) '$(fricas_src_srcdir)/etc/fricas-readline' '$(DESTDIR)$(bindir)/fricas-readline'
 	cat $(fricas_src_srcdir)/etc/fricas >> '${COMMAND}'.tmp
 	$(INSTALL_SCRIPT) '${COMMAND}'.tmp '${COMMAND}'
 	-rm '${COMMAND}'.tmp

--- a/src/etc/fricas
+++ b/src/etc/fricas
@@ -6,6 +6,7 @@
 #      [-ht   |-noht]       whether to use HyperDoc
 #      [-gr   |-nogr]       whether to use Graphics
 #      [-clef |-noclef]     whether to use Clef
+#      [-rl]                whether to use GNU Readline via rlwrap
 #      [-iw   |-noiw]       start in interpreter window
 #      [-ihere|-noihere]    start an interpreter buffer in the original window
 #      [-nox]               don't use X Windows
@@ -42,6 +43,14 @@ needsubopt () {
         ciao
 }
 
+
+have_rlwrap() {
+	if [ -z "$(command -v rlwrap)" ] ; then
+	    echo "Ignoring -rl option; rlwrap not found."
+	    return 1
+	fi
+        return 0
+}
 
 showuse() {
 echo "fricas"
@@ -115,7 +124,32 @@ fi
 
 if [ "$1" = "-nosman" ] ; then
     shift
-    exec "$FRICAS/bin/FRICASsys" "$@"
+
+    # Filter out -rl option.
+    opts=""
+    do_rlwrap=0
+    while [ "$*" != "" ] ; do
+        case $1 in
+        -rl)
+		if have_rlwrap ; then
+		    do_rlwrap=1
+		fi
+                ;;
+
+        *)
+		opts="$opts $1"
+                ;;
+        esac
+
+        shift
+    done
+
+    if [ $do_rlwrap -eq 1 ] ; then
+	exec rlwrap $FRICAS/bin/FRICASsys "$opts"
+    else
+	exec "$FRICAS/bin/FRICASsys" "$opts"
+    fi
+
     exit 1
 fi
 
@@ -158,6 +192,12 @@ while [ "$*" != "" ] ; do
                 ;;
         -clef|-noclef|-gr|-nogr|-ht|-noht|-iw|-noiw|-ihere|-noihere|-nox)
                 otheropts="$otheropts $1"
+                ;;
+
+        -rl)
+		if have_rlwrap ; then
+                    otheropts="$otheropts -clefprog ${exec_prefix}/bin/fricas-readline"
+		fi
                 ;;
 
         -h)

--- a/src/etc/fricas-readline
+++ b/src/etc/fricas-readline
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Wrapper to add GNU ReadLine support to fricas. See
+# Fricas FAQ:
+# 4.1: Clef does not work.  Is there an alternative?
+
+# Note: this script is not intended to be called directly, but is
+# called via another script, e.g. fricas
+
+CFILE=$2
+RLWRAP=${RLWAP:=rlwrap}
+shift 3
+exec $RLWRAP -f $CFILE "$@"


### PR DESCRIPTION
Adds option `-rl` (analogous to `-clef`) to trigger GNU ReadLine support

From FriCAS's FAQ:
> 4.1: Clef does not work.  Is there an alternative?
> ...

This incorprorates the code that follow into the basic install.

Also, some basic `.gitignore`s have been started. More is desireable
though.