### PR TITLE
doc: book: add missing backslash to Tex command

### DIFF
--- a/src/doc/htex/ug06.htex
+++ b/src/doc/htex/ug06.htex
@@ -294,7 +294,7 @@ The type of a function is always a mapping of the form
 where \spadtype{Source} and \spadtype{Target} are types.
 To enter a type from the keyboard, enter the arrow by using
 a hyphen \spadSyntax{-} followed by a greater-than sign
-\spadSyntax{>}, e.g. spadtype{Integer -> Integer}.
+\spadSyntax{>}, e.g. \spadtype{Integer -> Integer}.
 
 Let's go back to \spadop{+}.
 There are many \spadop{+} functions in the


### PR DESCRIPTION
A spadtype Tex command was missing its backslash.