### PR TITLE
fricas wrapper: use uname -n instead of hostname

### DIFF
--- a/src/etc/fricas
+++ b/src/etc/fricas
@@ -4,7 +4,7 @@ PATH=$FRICAS/bin:${PATH}:/usr/bin/X11
 export PATH
 
 # NAGMAN needs to know the hostname
-HOST=`hostname`
+HOST=`uname -n`
 export HOST
 
 # 0. Basic utilities


### PR DESCRIPTION
The two commands are equivalent, but uname -n is more portable. Namely,
uname is in POSIX/SUS, while hostname isn't.