### PR TITLE
doc: awk regexp escaping fixes

### DIFF
--- a/src/doc/ht.awk
+++ b/src/doc/ht.awk
@@ -185,7 +185,7 @@ inXmpLines==1 {
         gsub(/\\bs\\{\\}/, "\\bs{}")
         gsub(/ /, "\\ ")
         gsub(/&/, "\\\\&")
-        gsub(/\#/, "\\#")
+        gsub(/#/, "\\#")
         gsub(/\$/, "\\$")
         gsub(/%/, "\\%")
         gsub(/_/, "\\_")
@@ -532,7 +532,7 @@ function escapeArg(arg) {
         gsub(/\\bs\\{\\}/, "\\bs{}", arg)
         gsub(/\$/, "\\$", arg)
         gsub(/&/, "\\\\&", arg)
-        gsub(/\#/, "\\#", arg)
+        gsub(/#/, "\\#", arg)
         gsub(/_/, "\\_", arg)
         gsub(/%/, "\\%", arg)
 #        gsub(/^/, "\\^", arg) # not necessary

--- a/src/doc/htex2input.awk
+++ b/src/doc/htex2input.awk
@@ -72,9 +72,9 @@ xtc==2 && (/^\\spadcommand{/ || /^\\spadgraph{/) {
     gsub(/^\\spadgraph{/, "")
     gsub(/}$/, "")
     gsub(/\\\$/, "$")
-    gsub(/\\\%/, "%")
-    gsub(/\\\#/, "#")
-    gsub(/\\\_/, "_")
+    gsub(/\\%/, "%")
+    gsub(/\\#/, "#")
+    gsub(/\\_/, "_")
     gsub(/\\free{.*/, "")
     gsub(/\\bound{.*/, "")
     print "-- " $0

--- a/src/doc/spool2tex.awk
+++ b/src/doc/spool2tex.awk
@@ -36,7 +36,7 @@ BEGIN {
 /^-- \\begin{inputonly}/,/^-- \\end{inputonly}/ {next}
 
 # start of xtc
-/^-- \\begin{xtc}/ || /^-- \begin{noOutputXtc}/ {
+/^-- \\begin{xtc}/ || /^-- \\begin{noOutputXtc}/ {
     inxtc=1
     sub(/^-- /, "")
     print $0
@@ -54,7 +54,7 @@ inxtc==0 {
 # For everything below xtc>0.
 
 # end of xtc
-/^-- \end{xtc}$/ || /^-- \end{noOutputXtc}$/ {
+/^-- \\end{xtc}$/ || /^-- \\end{noOutputXtc}$/ {
     printf("%s\n",substr($0,4))
     inxtc=0
     next

--- a/src/doc/ugepsf.awk
+++ b/src/doc/ugepsf.awk
@@ -5,7 +5,7 @@
     n=0
 }
 
-(/:\\\psXtc/ || /:\\xtc/ || /:\\noOutputXtc/ || /:\\nullXtc/) {n++}
+(/:\\psXtc/ || /:\\xtc/ || /:\\noOutputXtc/ || /:\\nullXtc/) {n++}
 
 /:\\spadgraph/ {spadgraph=1}
 


### PR DESCRIPTION
Add missing backslashes, remove superfluous backslashes.