### PR TITLE
fix typo: unistall -> uninstall

### DIFF
--- a/src/lisp/Makefile.in
+++ b/src/lisp/Makefile.in
@@ -92,7 +92,7 @@ num_gmpx.lisp: $(srcdir)/num_gmp.lisp
 	else \
 	    (echo '(in-package "FRICAS-LISP")' ; \
 	     echo '(defun init-gmp(x) nil)' ; \
-	     echo '(defun unistall-gmp-multiplication() nil)') > $@ ; \
+	     echo '(defun uninstall-gmp-multiplication() nil)') > $@ ; \
 	fi
 
 fricas-config.lisp:

--- a/src/lisp/fricas-lisp.lisp
+++ b/src/lisp/fricas-lisp.lisp
@@ -124,7 +124,7 @@ with this hack and will try to convince the GCL crowd to fix this.
          (save-options-arg
              (if save-options-keyword (list save-options-keyword t) nil))
         )
-        (unistall-gmp-multiplication)
+        (uninstall-gmp-multiplication)
         (apply #'sb-ext::save-lisp-and-die
               (append `(,core-image :toplevel ,top-fun :executable t)
                       save-options-arg))

--- a/src/lisp/num_gmp.lisp
+++ b/src/lisp/num_gmp.lisp
@@ -598,7 +598,7 @@
     (setf *PACKAGE* package))
 )
 
-(defun unistall-gmp-multiplication()
+(defun uninstall-gmp-multiplication()
    (let ((package *PACKAGE*))
     (ccl:SET-DEVELOPMENT-ENVIRONMENT T)
     (setf (symbol-function 'ccl::multiply-bignums)
@@ -795,10 +795,9 @@
     (sb-ext:unlock-package "COMMON-LISP")
     (setf (symbol-function 'common-lisp:isqrt)
           (symbol-function 'gmp-isqrt))
-    (sb-ext:lock-package "COMMON-LISP")
-)
+    (sb-ext:lock-package "COMMON-LISP"))
 
-(defun unistall-gmp-multiplication()
+(defun uninstall-gmp-multiplication()
     (sb-ext:unlock-package "SB-BIGNUM")
     (setf (symbol-function 'sb-bignum::multiply-bignums)
           (symbol-function 'orig-multiply-bignums))
@@ -810,9 +809,7 @@
     (sb-ext:unlock-package "COMMON-LISP")
     (setf (symbol-function 'common-lisp:isqrt)
           (symbol-function 'orig-isqrt))
-    (sb-ext:lock-package "COMMON-LISP"))
-
-)
+    (sb-ext:lock-package "COMMON-LISP")))
 
 (defun init-gmp(wrapper-lib)
     (if (not *gmp-multiplication-initialized*)
@@ -821,6 +818,4 @@
                     (|quiet_load_alien| wrapper-lib) t)
                 (progn
                     (install-gmp-multiplication)
-                    (setf *gmp-multiplication-initialized* t))))))
-
-)
+                    (setf *gmp-multiplication-initialized* t)))))))


### PR DESCRIPTION
Fixes a simple typo `unistall-gmp-multiplication` -> `uninstall-gmp-multiplication`.