### PR TITLE
specify boot/spad as text and lisp/clisp as Common Lisp

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
 * text=auto eol=lf
+
+*.boot linguist-language=Text
+*.spad linguist-language=Text
+*.lisp linguist-language=Common-Lisp
+*.clisp linguist-language=Common-Lisp
+


### PR DESCRIPTION
GitHub currently gravely misclassifies the contents of the repository. This commit ensures `.lisp` and `.clisp` are seen as Common Lisp files, and `.boot` and `.spad` are seen as text files.

GitHub obviously doesn't recognize `.boot` and `.spad` as languages on their own, and that would require changes to a Ruby project called "Linguist". Linguist also doesn't have support for "custom" or "unknown" languages, so we make a best effort compromise and just list those files as text files.