### PR TITLE
.gitattributes: boot files are not Clojure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 * text=auto eol=lf
+
+# Tell GitHub that .boot files are not Clojure.
+*.boot linguist-language=Spad 
+*.spad linguist-language=Spad


### PR DESCRIPTION
Hi, discovering FriCAS, a fork of Axiom, was great, but seeing it was composed mainly of Clojure code, as GitHub says, was puzzling. It turns out .boot files are counted as Clojure ([example](https://github.com/fricas/fricas/blob/master/src/interp/msg.boot)), but I am pretty sure they are not. 

I edited the .gitattributes to teach GitHub ([doc](https://github.com/github/linguist/blob/master/docs/overrides.md)). However, are they Spad files?

With this PR, the language count becomes: 41% C, 30% PostScript, 10% Common Lisp etc instead of 33% Clojure.

(Shall we go further and count .spad files as Lisp??)

Regards,
