### PR TITLE
Remove extraneous RPLACD from dqAppend

### DIFF
--- a/src/boot/btscan2.boot
+++ b/src/boot/btscan2.boot
@@ -41,7 +41,6 @@ dqAppend(x,y)==
     else if null y
          then x
          else
-              RPLACD (CDR x,CAR y)
               RPLACD (x,    CDR y)
               x
 


### PR DESCRIPTION
In the function dqAppend there are two occurrences of RPLACD, the first call is overwritten
by the second call and so it is removed

Signed-off-by: Bruce Rennie <brennie@dcsi.net.au>