### PR TITLE
fix for change in calling convention in Emacs 28

### DIFF
--- a/contrib/emacs/fricas.el
+++ b/contrib/emacs/fricas.el
@@ -323,8 +323,7 @@ using \\[rename-buffer] or \\[rename-uniquely] and start a new FriCAS process.
   "Run FriCAS in the current BUFFER."
   (message "Starting FriCAS...")
   (start-process-shell-command "fricas" (current-buffer)
-                               fricas-run-command
-                               "-emacs"))
+                               (concat fricas-run-command " -emacs")))
 
 (defun fricas-check-proc (buffer)
   "Return non-nil if there is a living process associated w/buffer BUFFER.


### PR DESCRIPTION
https://www.gnu.org/software/emacs/news/NEWS.28.1

'start-process-shell-command' and 'start-file-process-shell-command'
do not support the old calling conventions any longer.