### PR TITLE
fix elt(x,universalsegment)

### DIFF
--- a/src/algebra/aggcat.spad
+++ b/src/algebra/aggcat.spad
@@ -1655,13 +1655,6 @@ StreamAggregate(S : Type) : Category ==
            error "index out of range"
        first x
 
-   elt(x : %, i : UniversalSegment(Integer)) ==
-       l := low(i) - minIndex x
-       l < 0 => error "index out of range"
-       not hasHi i => copy(rest(x, l::NonNegativeInteger))
-       (h := high(i) - minIndex x) < l => empty()
-       first(rest(x, l::NonNegativeInteger), (h - l + 1)::NonNegativeInteger)
-
    if % has shallowlyMutable then
 
        concat(x : %, y : %) == concat!(copy x, y)
@@ -2042,14 +2035,23 @@ OneDimensionalArrayAggregate(S : Type) : Category ==
         for k in k.. for j in j..n repeat qsetelt!(r, k, elt(b, j))
         r
 
-    elt(a : %, s : UniversalSegment(Integer)) ==
-        l := low(s)
-        h := if hasHi s then high(s) else maxIndex a
-        l < minIndex a or h > maxIndex a => error "index out of range"
-        r := stupidnew(max(0, h - l + 1)::NonNegativeInteger, a, a)
-        for k in minIndex r.. for i in l..h repeat
-            qsetelt!(r, k, qelt(a, i))
-        r
+    elt(x : %, seg : UniversalSegment(Integer)) ==
+        step := incr seg
+        zero? step => error "zero step size"
+        mn := minIndex x
+        mx := maxIndex x
+        lo := low seg
+        bound := if step < 0 then mn else mx
+        hi := if hasHi seg then high seg else bound
+        -- Compute the number of entries.
+        n: Integer := sign(step)*(hi-lo)
+        n < 0 => empty()
+        n := 1 + ((hi - lo) quo step)
+        z: % := new(n::NonNegativeInteger, qelt(x, mn))
+        -- There will be out of range errors if x.i cannot be accessed.
+        for i in lo .. hi by step for j in mn .. repeat
+            qsetelt!(z, j, qelt(x, i))
+        z
 
     insert(a : %, b : %, i : Integer) ==
         m := minIndex b
@@ -2360,6 +2362,37 @@ ListAggregate(S : Type) : Category == Join(StreamAggregate S,
        r := i
        while not empty? x repeat (r := f(r, first x); x := rest x)
        r
+
+   elt(x : %, seg : UniversalSegment(Integer)) ==
+       step := incr seg
+       zero? step => error "zero step size"
+       mn := minIndex x
+       mx := maxIndex x
+       neg?: Boolean := step < 0
+       if neg? then
+           step := - step
+           lo := if hasHi seg then high seg else mn
+           hi := low seg
+           lo > hi => return empty()
+           hi > mx => error "index out of range"
+           lo := hi - step*((hi-lo) quo step) -- adapt to exact bounds
+           lo < mn => error "index out of range"
+         else
+           hi := if hasHi seg then high seg else mx
+           lo := low seg
+           lo > hi => return empty()
+           lo < mn or lo > mx => error "index out of range"
+           hi := lo + step*((hi-lo) quo step) -- adapt to exact bounds
+           hi > mx => error "index out of range"
+       l: % := empty()
+       z := rest(x, (lo-mn) :: NonNegativeInteger)
+       while lo < hi repeat
+           l := concat(first z, l)
+           z := rest(z, step :: NonNegativeInteger)
+           lo := lo + step
+       l := concat(first z, l)
+       neg? => l
+       reverse! l
 
    if S has BasicType then
        reduce(f, x, i, a) ==

--- a/src/algebra/seg.spad
+++ b/src/algebra/seg.spad
@@ -346,7 +346,7 @@ UniversalSegment(S : Type) : SegmentCategory(S) with
     SEGMENT(a) == segment a
     SEGMENT(a, b) == segment(a, b)
 
-    coerce(sg : Segment S) : % == segment(low(sg), high(sg))
+    coerce(sg : Segment S) : % == sg
 
     convert a == convert(a)$Rec
 

--- a/src/algebra/stream.spad
+++ b/src/algebra/stream.spad
@@ -9,6 +9,12 @@
 ++ cause lazy evaluation if necessary to determine if there are
 ++ entries.  Functions which call 'empty?', e.g. 'first' and 'rest',
 ++ will also cause lazy evaluation if necessary.
+++ Elements of LazyStreamAggregate are computed only when strictly
+++ needed.  Lazy computation means that potential errors are
+++ delayed, so errors are detected later than in case of normal
+++ (eager) evaluation used by other aggregates.  In some cases
+++ computation that would signal error when using eager evaluation
+++ can succeed when using lazy evaluation.
 
 LazyStreamAggregate(S : Type) : Category == StreamAggregate(S) with
   remove : (S -> Boolean, %) -> %
@@ -289,17 +295,6 @@ LazyStreamAggregate(S : Type) : Category == StreamAggregate(S) with
       concat(first(x, (low - MIN) :: NNI), rest(x, (high - MIN + 1) :: NNI))
     not index?(low,x) => error "delete: index out of range"
     first(x, (low - MIN) :: NNI)
-
-  elt(x : %, seg : U) ==
-    low := low(seg)
-    hasHi seg =>
-      high := high(seg)
-      high < low => empty()
-      (not index?(low, x)) or (not index?(high, x)) =>
-        error "elt: index out of range"
-      first(rest(x, (low - MIN) :: NNI), (high - low + 1) :: NNI)
-    not index?(low,x) => error "elt: index out of range"
-    rest(x, (low - MIN) :: NNI)
 
   insert(s : S, x : %, n : I) ==
     not index?(n,x) => error "insert: index out of range"
@@ -1098,6 +1093,64 @@ Stream(S : Type) : Exports == Implementation where
         p(frst x) => concat(frst x, empty())
         x
       suntill(p, x)
+
+--% STAGG functions
+
+  -- local
+    ms(m: I, n: I, s: %): % == delay
+      empty? s => empty()
+      zero? n => concat(frst s, ms(m, m-1, rst s))
+      ms(m, n-1, rst s)
+
+    -- local
+    eltPositiveStep(x : %, seg : U): % == delay
+      step := incr seg
+      lo := low seg
+      hasHi seg =>
+        hi := high seg
+        hi < lo => empty()
+        hi := lo + step*((hi-lo) quo step)
+        z := first(rest(x, (lo - MIN) :: NNI), (hi - lo + 1) :: NNI)
+        one? step => z
+        ms(step, 0, z)
+      z := rest(x, (lo - MIN) :: NNI)
+      one? step => copy z
+      ms(step, 0, z)
+
+    -- local
+    errorStream(): % == delay error "elt: no evaluation possible"
+
+    -- local
+    eltNegativeStep(x : %, seg : U): % == delay
+      step := - incr seg
+      hi := low seg
+      lo := if hasHi seg then high seg else MIN
+      lo > hi => empty()
+      lo := hi - step*((hi-lo) quo step) -- adapt to exact bounds
+      mustEventuallyFail?: Boolean := lo < MIN
+      if mustEventuallyFail? then
+        lo := hi - step*((hi-MIN) quo step) -- adapt to exact bounds
+      z := rest(x, (lo - MIN) :: NNI)
+      l: % := empty()
+      while lo < hi repeat
+        l := concat(first z, l)
+        z := rest(z, step :: NonNegativeInteger)
+        lo := lo + step
+      result := concat(first z, l)
+      -- If mustEventuallyFail? then we would eventually access a
+      -- non-existing stream element of x, so we create a finite
+      -- stream z of n elements that will give an error for
+      -- "empty?(rest(z, n)). This signals that according to the
+      -- creation that stream would not be empty, but the next element
+      -- would access x(k) for k<MIN.
+      mustEventuallyFail? => concat(result, errorStream())
+      result
+
+    elt(x : %, seg : U): % ==
+      step := incr seg
+      zero? step => error "zero step size"
+      step > 0 => eltPositiveStep(x, seg)
+      eltNegativeStep(x, seg)
 
 --  if S has SetCategory then
 --    mapp: ((S, S) -> S, %, %, S) -> %

--- a/src/input/Makefile.in
+++ b/src/input/Makefile.in
@@ -143,7 +143,7 @@ REGRESS = agcd.output array.output bezout.output bugs2007.output \
       bugs2019.output  bugs2020.output  bugs2021.output  bugs2022.output \
       charpol.output cyldec.output derham.output \
       dirichlet.output discrgrp.output distro.output \
-      ellip.output expps.output \
+      ellip.output eltuniseg.output expps.output \
       fftst.output finite.output free_mod.output fun.output gpresent.output \
       integ.output intlocp.output isprime.output \
       limit.output linalg2.output lll.output \
@@ -157,12 +157,13 @@ REGRESS = agcd.output array.output bezout.output bugs2007.output \
 check: regression-tests
 	awk -f $(srcdir)/check_result $(REGRESS)
 
-READINS = conformal.input
+READINS = conformal.input eltunisegtests.input
 
 ${READINS}: %.input : $(srcdir)/%.input
 	cp $< $@
 
 fixed.output: conformal.input
+eltuniseg.output: eltunisegtests.input
 
 .PHONY: regression-tests
 regression-tests: ${REGRESS}

--- a/src/input/eltuniseg.input
+++ b/src/input/eltuniseg.input
@@ -1,0 +1,80 @@
+)clear complete
+)set break resume
+)expose UnittestCount UnittestAux Unittest
+
+-------------------------------------------------------------------
+testsuiteNoClear "elt-UniversalSegment"
+-------------------------------------------------------------------
+
+-- Expand to a list, but at most n elements and no entries below 1 or
+-- above b.
+EX(u,n,b) ==> "entries complete([v for v in [k for k in " u " while (k > 0 and k <= " string(b) ")] for m in 1.." string(n) "]::Stream(Integer))"
+
+-- Stepsize=0 is a special case and not allowed, i.e. leads to
+-- an immediate error even in the lazy case.
+TESTBY0 u ==> testLibraryError("x(" u " by 0);") -- do not print the result
+
+-------------------------------------------------------------------
+-------------------------------------------------------------------
+
+testcaseNoClear "List"
+
+x: List Integer := [i for i in 1..29]
+TESTFIN u ==> testEquals("x(" u ")", EX(u, 29, 29))
+TESTEMPTY u ==> testEquals("x(" u ")", "[]")
+TESTEMPTYINF u ==> TESTEMPTY u
+TESTSTREAM u ==> TESTFIN u
+TESTMIN(u, i) ==> testLibraryError("x(" u ")")
+TESTMAX(u, i) ==> testLibraryError("x(" u ")")
+)read eltunisegtests
+
+-------------------------------------------------------------------
+
+testcaseNoClear "Vector"
+
+)clear prop x TESTFIN
+x: Vector Integer := vector [i for i in 1..29]
+TESTFIN u ==> testEquals("x(" u ")", "vector " EX(u, 29, 29))
+)read eltunisegtests
+
+-------------------------------------------------------------------
+
+testcaseNoClear "Stream-finite"
+
+)clear prop x TESTFIN TESTEMPTY TESTMIN TESTMAX
+x: Stream Integer := [i for i in 1..29]
+TESTFIN u ==> testEquals("entries complete x(" u ")", EX(u,29, 29))
+-- Check that creation of structure gives no error, but access does.
+TESTEMPTY u ==> testEquals("entries complete x(" u ")", "[]")
+TESTMIN(u, i) ==>
+  testTrue("x(" u "); true") -- no error
+  -- test access to all indices before the bad index
+  testTrue("t := x(" u "); (#[t.n for n in 1..(" i "-1)]=" i "-1)@Boolean")
+  -- first index that raises error
+  testLibraryError("t := x(" u "); t." i)
+TESTMAX(u, i) ==> TESTMIN(u, i)
+)read eltunisegtests
+
+-------------------------------------------------------------------
+
+testcaseNoClear "Stream-infinite"
+
+)clear prop x TESTSTREAM TESTEMPTYINF TESTMAX
+x: Stream Integer := [i for i in 1..]
+TESTSTREAM u ==> testEquals("t:=x(" u "); [t.n for n in 1..99]",
+                    "entries complete [k for k in " u " for m in 1..99]")
+TESTEMPTYINF u ==> TESTSTREAM u
+-- There is no maximal index for an infinite stream, i.e. no error.
+-- We check at most 99 coefficients and can ignore the i argument.
+TESTMAX(u, i) ==> _
+  testEquals("t:=x(" u ");"_
+             "l:=empty()$List(Integer);"_
+             "for n in 1..99 while not empty? t repeat"_
+             "  (l := cons(first t, l); t := rest t);"_
+             "reverse! l",_
+             EX(u, 99, 99))
+)read eltunisegtests
+
+-------------------------------------------------------------------
+
+statistics()

--- a/src/input/eltunisegtests.input
+++ b/src/input/eltunisegtests.input
@@ -1,0 +1,72 @@
+-- This file is meant to be read by the unittest fils eltuniseg.input.
+-- -----------------------------------------------------------------
+-- Collect common tests for different structures. There are, in fact,
+-- four different cases, namely, (1) lists, (2) arrays/vectors, (3)
+-- finite streams, (4) infinite streams.
+--
+-- The tests are described by macros that expand differently for those
+-- different cases.
+--
+-- We do not currently allow cyclic lists or streams.
+-- -----------------------------------------------------------------
+TESTFIN("4..17")
+TESTFIN("4..27 by 3")
+TESTFIN("4..27 by 13")
+TESTFIN("4..30 by 5") -- we never need x(30)
+
+TESTFIN("27..4 by -3")
+TESTFIN("27..3 by -3")
+TESTFIN("27..4 by -13")
+TESTFIN("27..0 by -4") -- we never access x(0)
+
+TESTFIN("4.. by -3")
+TESTFIN("4.. by -73")
+TESTFIN("29.. by -3")
+
+-- possibly infinite result in infinite stream case
+TESTSTREAM("4..")
+TESTSTREAM("4.. by 3")
+TESTSTREAM("4.. by 73")
+
+-- empty segment
+TESTEMPTY("27..14")
+TESTEMPTY("3..14 by -4")
+TESTEMPTY("0..30 by -3")
+TESTEMPTY("14..3 by 3")
+TESTEMPTY("30..0")
+TESTEMPTY("30..0 by 3")
+-- The following is equivalent to x(0..minIndex(x) by -3) = empty
+TESTEMPTY("0.. by -3") -- we never need to access x(0)
+
+-- In the list and vector case the segment should be equivalent to
+-- 40..29, i.e. the empty structure should be returned.
+-- In the finite stream case, an explicitly empty stream is returned.
+-- In the infinite stream case, both are OK and give an infinite stream.
+TESTEMPTYINF("40..")
+TESTEMPTYINF("40.. by 3")
+
+-- For TESTMIN(u,i) and TESTMAX(u,i) an error may occur (depending
+-- on the underlying structure, if index i of the result is accessed.
+
+-- "index out of range" below minIndex (delayed error in stream case)
+TESTMIN("0..27",       "1")
+TESTMIN("0..27 by 3",  "1")
+TESTMIN("0..30 by 29", "1")
+TESTMIN("0..",         "1")
+TESTMIN("0.. by 3",    "1")
+TESTMIN("-4.. by 3",   "1")
+-- "index out of range" below minIndex (delayed error in stream case)
+TESTMIN("28..0 by -4", "8")
+
+-- "index out of range" above maxIndex (delayed error in finite stream case)
+-- No problem for infinite streams.
+TESTMAX("23..30",       "8")
+TESTMAX("11..50 by 3",  "8")
+TESTMAX("30..40 by 30", "1")
+TESTMAX("30..4 by -3",  "1")
+TESTMAX("30.. by -3",   "1")
+
+-- "zero step size" -- immedoate error in all cases
+TESTBY0("4..27")
+TESTBY0("4..")
+TESTBY0("27..4")


### PR DESCRIPTION
First commit fixes Segment -> UniversalSegment coercion by taking also the stepsize into account.
Second commit allows to use a stepsize in x(a..b by s) to select part of a list or stream.