### PR TITLE
Detect buggy sbcl versions on 32-bit platforms

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-06-11  Qian Yun  <oldk1331@gmail.com>
+
+	* configure.ac: Detect buggy sbcl versions on
+	32-bit platforms
+
 2022-06-07  Waldek Hebisch  <cas@fricas.math.uni.wroc.pl>
 
 	* src/algebra/sf.spad, src/algebra/special.spad,

--- a/configure
+++ b/configure
@@ -4157,6 +4157,15 @@ $as_echo "$as_me: WARNING: FriCAS needs porting to gcl $fricas_lisp_version
            echo $fricas_lisp_version | grep '^1\.0.[0-6]$' > /dev/null ; then
              as_fn_error $? "sbcl $fricas_lisp_version is too old" "$LINENO" 5
         fi
+        case $(uname -m) in
+           i*86)
+             case $fricas_lisp_version in
+                1.5.9|2.0.*|2.1.[0-3].*)
+                  as_fn_error $? "sbcl $fricas_lisp_version on $(uname -m) has a serious runtime issue. Please use different sbcl version" "$LINENO" 5
+                    ;;
+             esac
+               ;;
+        esac
         case $fricas_lisp_version in
            1.0.29|1.3.1|1.3.1.*|1.3.2|1.3.3|1.3.4)
              as_fn_error $? "sbcl $fricas_lisp_version has a bug which does not allow building FriCAS.

--- a/configure.ac
+++ b/configure.ac
@@ -279,6 +279,15 @@ else
            echo $fricas_lisp_version | grep '^1\.0.[[0-6]]$' > /dev/null ; then
              AC_MSG_ERROR([sbcl $fricas_lisp_version is too old])
         fi
+        case $(uname -m) in
+           i*86)
+             case $fricas_lisp_version in
+                1.5.9|2.0.*|2.1.[[0-3]].*)
+                  AC_MSG_ERROR([sbcl $fricas_lisp_version on $(uname -m) has a serious runtime issue. Please use different sbcl version])
+                    ;;
+             esac
+               ;;
+        esac
         case $fricas_lisp_version in
            1.0.29|1.3.1|1.3.1.*|1.3.2|1.3.3|1.3.4)
              AC_MSG_ERROR([sbcl $fricas_lisp_version has a bug which does not allow building FriCAS.


### PR DESCRIPTION
As discussed in https://github.com/fricas/fricas/issues/55, this patch checks for buggy sbcl versions on 32-bit platforms, to prevent people from falling into this issue again.