### PR TITLE
Fix environment variable on macOS to make dmg package work out of box

### DIFF
--- a/contrib/macos/FriCAS.c
+++ b/contrib/macos/FriCAS.c
@@ -22,10 +22,12 @@ int main(int argc, const char *argv[]) {
   CFStringAppend(path, prefix);
   CFStringAppendCString(path, "/", encoding);
   CFStringAppend(path, resources);
+  CFStringAppendCString(path, "/usr/local/", encoding);
 
   setenv("FRICAS_PREFIX", CFStringGetCStringPtr(path, encoding), 1);
 
   system("open -a Terminal.app"
-         " \"${FRICAS_PREFIX}/usr/local/bin/fricas\"");
+         " -n --env FRICAS_PREFIX=\"${FRICAS_PREFIX}\""
+         " \"${FRICAS_PREFIX}/bin/fricas\"");
   return 0;
 }


### PR DESCRIPTION
This patch correctly set environment variable, so that we can start fricas from terminal and from "double click app icon", without hack.