### PR TITLE
Fix build with CLISP-2.49.92

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -476,6 +476,8 @@ Known problems
   Alternatively for sbcl one can use "--dynamic-space-size" argument
   to decrease use of virtual memory.
 
+- CLISP built with threads support may fail to compile FriCAS.
+
 - On new Linux kernel build using Clisp may take very long time.  This
   is caused by frequent calls to "fsync" performed without need by
   Clisp.

--- a/src/doc/sphinx/source/install.rst
+++ b/src/doc/sphinx/source/install.rst
@@ -524,6 +524,8 @@ Known problems
   Alternatively for sbcl one can use ``--dynamic-space-size`` argument
   to decrease use of virtual memory.
 
+- CLISP built with threads support may fail to compile FriCAS.
+
 - On new Linux kernel build using Clisp may take very long time.  This
   is caused by frequent calls to ``fsync`` performed without need by
   Clisp.

--- a/src/interp/util.lisp
+++ b/src/interp/util.lisp
@@ -326,10 +326,18 @@ After this function is called the image is clean and can be saved.
 (DEFVAR CUROUTSTREAM *standard-output*)
 
 (defun fricas-restart ()
-  ;;; Need to reinitialize CUROUTSTREAM and |$trace_stream| because
-  ;;;  clisp closes it when dumping executable
+  ;;; Need to reinitialize various streams because
+  ;;; CLISP closes them when dumping executable
   (setf CUROUTSTREAM *standard-output*)
   (setf |$trace_stream| *standard-output*)
+  (setq |$algebraOutputStream| (|mkOutputConsoleStream|))
+  (setq |$fortranOutputStream| (|mkOutputConsoleStream|))
+  (setq |$mathmlOutputStream| (|mkOutputConsoleStream|))
+  (setq |$texmacsOutputStream| (|mkOutputConsoleStream|))
+  (setq |$htmlOutputStream| (|mkOutputConsoleStream|))
+  (setq |$openMathOutputStream| (|mkOutputConsoleStream|))
+  (setq |$texOutputStream| (|mkOutputConsoleStream|))
+  (setq |$formattedOutputStream| (|mkOutputConsoleStream|))
   (fricas-init)
   #+(or :GCL :poplog)
   (|spad|)

--- a/src/lisp/fricas-lisp.lisp
+++ b/src/lisp/fricas-lisp.lisp
@@ -877,7 +877,11 @@ with this hack and will try to convince the GCL crowd to fix this.
 
 #+:clisp
 (defun makedir (fname)
-    (ext:make-dir (pad-directory-name (namestring fname))))
+  ;; ext:make-dir was deprecated in clisp-2.44-2008-02-02
+  ;; and removed in clisp-2.49.90-2018-02-11
+  (let ((sym (or (find-symbol "MAKE-DIRECTORY" "EXT")
+                 (find-symbol "MAKE-DIR" "EXT"))))
+    (funcall sym (pad-directory-name (namestring fname)))))
 
 #+:lispworks
 (defun makedir (fname)


### PR DESCRIPTION
Finally I have build FriCAS successfully with CLISP-2.49.92.

1. I can not build FriCAS with CLISP-2.49. (which is released in 2010).
2. I can build FriCAS with CLISP-2.49.92 (latest snapshot, released in 2018) or CLISP git version. (the development seems to be stalled, however.)
3. The CLISP must be built without threads support. If built with `--with-threads=POSIX_THREADS`, errors will happen when compiling SPAD files.

Some notes about the patch:
1. `ext:make-dir` is deprecated in 2007 and removed in 2017. So use `ext:make-directory` instead.
2. `interpsys` can not wirte to `$algebraOutputStream` because CLISP think it is closed. So initialize it again.

Please give this patch a review.  And if possible, test it on your system and see if CLISP can build FriCAS on your system.

I will update `INSTALL` section on CLISP later.