### PR TITLE
integ.input: remove Zolotarev integral, fixed typo

### DIFF
--- a/src/input/integ.input
+++ b/src/input/integ.input
@@ -61,9 +61,7 @@ testIntegrate("(1+x^(1/4))^(1/3)/(x^(1/2))", "x", "alg")
 testIntegrate("((-x-1)*log((x^2+x))^2+2*log(x))/(x+1)", "x", "elem")
 testIntegrate("x/sqrt((1-x^2)*(1-k^2*x^2))", "x", "alg")
 testIntegrate("sqrt(1/x+1)*sqrt(x)-sqrt(x+1)", "x", "alg")
--- Abel example
-testIntegrate("(5*x-1)/sqrt(x^4 + 2*x^2 - 4*x + 1)", "x", "alg")
--- Massetr and Zanier
+-- Masser and Zannier
 testIntegrate("5*x^2/sqrt(x^6 +x)", "x", "alg")
 
 -- used to fail due to wrong normalization


### PR DESCRIPTION
See e.g. https://en.wikipedia.org/wiki/Yegor_Ivanovich_Zolotarev


There is really no need to test Zolotarev integral, this is a very common case, which is the first mentioned on https://en.wikipedia.org/wiki/Risch_algorithm