### PR TITLE
Fix ICARD retrieval of constructor abbreviation.

### DIFF
--- a/src/algebra/alql.spad
+++ b/src/algebra/alql.spad
@@ -104,7 +104,7 @@ IndexCard() : Exports == Implementation where
         s = 'nargs => db_part(x, 2, 1)
         s = 'exposed => db_part(x, 3, 1)(1..1)
         s = 'type => db_part(x, 4, 1)
-        s = 'abbreviation => db_part(x, 5, 1)
+        s = 'abbreviation => db_part(x, 6, 1)
         s = 'kind => alql_get_kind(x)
         s = 'origin => alql_get_origin(x)
         s = 'params => alql_get_params(x)


### PR DESCRIPTION
The IndexCard domain uses the wrong field number to retrieve a constructor's abbreviation from the libdb.text file.

This pull-request fixes that problem.

Thanks,
Paul
