### PR TITLE
load correct gmp library on windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: msys2/setup-msys2@v2
       with:
-        install: make mingw-w64-x86_64-gcc zip
+        install: make mingw-w64-x86_64-gcc mingw-w64-x86_64-gmp gmp-devel zip
     - name: download SBCL
       run: wget https://downloads.sourceforge.net/project/sbcl/sbcl/2.2.5/sbcl-2.2.5-x86-64-windows-binary.msi
     - name: install SBCL
@@ -27,7 +27,7 @@ jobs:
         export SBCL_HOME="/c/sbcl/PFiles/Steel Bank Common Lisp/"
         export PATH="$SBCL_HOME":$PATH
         mkdir ../build && cd ../build
-        ../fricas/configure --with-lisp=sbcl || cat config.log
+        ../fricas/configure --with-lisp=sbcl --enable-gmp || cat config.log
         make -j2 --output-sync
     - name: make check
       run: cd ../build && make check -j2 --output-sync

--- a/src/lisp/num_gmp.lisp
+++ b/src/lisp/num_gmp.lisp
@@ -826,7 +826,10 @@
 
 (defun init-gmp(wrapper-lib)
     (if (not *gmp-multiplication-initialized*)
-        (if (ignore-errors (|quiet_load_alien| "libgmp.so") t)
+        (if (ignore-errors (|quiet_load_alien|
+                            #-:WIN32 "libgmp.so"
+                            #+:WIN32 "libgmp-10.dll"
+                            ) t)
             (if (ignore-errors
                     (|quiet_load_alien| wrapper-lib) t)
                 (progn


### PR DESCRIPTION
Next question is whether we should bundle this gmp dll in our windows distribution.  I think the answer should be yes.
