### PR TITLE
use $spadroot instead of (|getEnv| "FRICAS")

### DIFF
--- a/src/interp/br-data.boot
+++ b/src/interp/br-data.boot
@@ -197,13 +197,13 @@ dbHasExamplePage conname ==
   sname    := STRINGIMAGE conname
   abb      := constructor? conname
   ucname   := UPCASE STRINGIMAGE abb
-  pathname :=STRCONC(getEnv '"FRICAS",'"/share/hypertex/pages/",ucname,'".ht")
+  pathname :=STRCONC($SPADROOT,'"/share/hypertex/pages/",ucname,'".ht")
   isExistingFile pathname => INTERN STRCONC(sname,'"XmpPage")
   nil
 
 dbReadComments(n) ==
   n = 0 => '""
-  instream := MAKE_INSTREAM(STRCONC(getEnv('"FRICAS"), '"/algebra/comdb.text"))
+  instream := MAKE_INSTREAM(STRCONC($SPADROOT, '"/algebra/comdb.text"))
   FILE_-POSITION(instream,n)
   line := read_line instream
   k := dbTickIndex(line,1,1)

--- a/src/interp/br-search.boot
+++ b/src/interp/br-search.boot
@@ -205,7 +205,7 @@ isFilterDelimiter? c == MEMQ(c,$pmFilterDelimiters)
 
 grepSplit(lines,doc?) ==
   if doc? then
-    instream2 := OPEN STRCONC(getEnv '"FRICAS",'"/algebra/libdb.text")
+    instream2 := OPEN STRCONC($SPADROOT,'"/algebra/libdb.text")
   cons := atts := doms := nil
   while lines is [line, :lines] repeat
     if doc? then

--- a/src/interp/daase.lisp
+++ b/src/interp/daase.lisp
@@ -307,7 +307,7 @@ database.
  "call the aldor compiler"
  (#| system::system |#
    obey
-   (concatenate 'string (|getEnv| "FRICAS") "/compiler/bin/aldor "
+   (concatenate 'string $spadroot "/compiler/bin/aldor "
     flags " " file)))
 
 (defun resethashtables ()
@@ -411,7 +411,7 @@ database.
   |Integer| |List| |OutputForm|))
  (dolist (con constr)
   (let ((c (concatenate 'string
-             (|getEnv| "FRICAS") "/algebra/"
+             $spadroot "/algebra/"
              (string (getdatabase con 'abbreviation)) "." |$lisp_bin_filetype|)))
     (format t "   preloading ~a.." c)
     (if (probe-file c)
@@ -1420,7 +1420,7 @@ database.
 
 ;; following needs to happen inside restart since $FRICAS may change
 (defun |createInitializers2| ()
- (let ((asharprootlib (strconc (|getEnv| "FRICAS") "/aldor/lib/")))
+ (let ((asharprootlib (make-absolute-filename  "/aldor/lib/")))
    (set-file-getter (strconc asharprootlib "runtime"))
    (set-file-getter (strconc asharprootlib "lang"))
    (set-file-getter (strconc asharprootlib "attrib"))

--- a/src/interp/ht-root.boot
+++ b/src/interp/ht-root.boot
@@ -130,7 +130,7 @@ htGlossPage(htPage,pattern,tryAgain?) ==
   grepForm := mkGrepPattern(filter,'none)
   $key: local := 'none
   results := applyGrep(grepForm,'gloss)
-  defstream := MAKE_INSTREAM(STRCONC(getEnv '"FRICAS",
+  defstream := MAKE_INSTREAM(STRCONC($SPADROOT,
                                      '"/algebra/glossdef.text"))
   lines := gatherGlossLines(results,defstream)
   heading :=

--- a/src/interp/htcheck.boot
+++ b/src/interp/htcheck.boot
@@ -80,7 +80,7 @@ $primitiveHtCommands := '(
 
 buildHtMacroTable() ==
   $htMacroTable := MAKE_HASHTABLE('UEQUAL)
-  fn := CONCAT(getEnv '"FRICAS", '"/share/hypertex/pages/util.ht")
+  fn := CONCAT($SPADROOT, '"/share/hypertex/pages/util.ht")
   if PROBE_-FILE(fn) then
     instream := MAKE_INSTREAM(fn)
     while not EOFP instream repeat

--- a/src/interp/i-syscmd.boot
+++ b/src/interp/i-syscmd.boot
@@ -704,9 +704,9 @@ withAsharpCmd args ==
 --% )copyright -- display copyright notice
 
 summary l ==
- OBEY STRCONC ('"cat ",getEnv('"FRICAS"),'"/lib/summary")
+ OBEY STRCONC ('"cat ",$SPADROOT,'"/lib/summary")
 copyright () ==
- OBEY STRCONC ('"cat ",getEnv('"FRICAS"),'"/lib/copyright")
+ OBEY STRCONC ('"cat ",$SPADROOT,'"/lib/copyright")
 
 --% )credits -- display credit list
 

--- a/src/interp/util.lisp
+++ b/src/interp/util.lisp
@@ -76,7 +76,7 @@ at load time.
 ;;; It is set up in the {\bf reroot} function.
 (defvar $library-directory-list ())
 
-;;; Prefix a filename with the {\bf FRICAS} shell variable.
+;;; Prefix a filename with the {\bf $spadroot} variable.
 (defun make-absolute-filename (name)
  (concatenate 'string $spadroot name))
 
@@ -87,13 +87,10 @@ the system. In particular, these variables are sensitive to the
 be {\bf \$spadroot}. The {\bf reroot} function will change the
 system to use a new root directory and will have the same effect
 as changing the {\bf FRICAS} shell variable and rerunning the system
-from scratch.  A correct call looks like:
-\begin{verbatim}
-(in-package "BOOT")
-(reroot "${FRICAS}")
-\end{verbatim}
-where the [[${FRICAS}]] variable points to installed tree.
+from scratch.
 |#
+(defvar $spadroot "")
+
 (defun reroot (dir)
   (setq $spadroot dir)
   (setq $directory-list
@@ -268,7 +265,7 @@ After this function is called the image is clean and can be saved.
  (cond
   ((load "./exposed" :verbose nil :if-does-not-exist nil)
     '|done|)
-  ((load (concat (|getEnv| "FRICAS") "/algebra/exposed")
+  ((load (make-absolute-filename "/algebra/exposed")
      :verbose nil :if-does-not-exist nil)
    '|done|)
   (t '|failed|) ))
@@ -288,10 +285,9 @@ After this function is called the image is clean and can be saved.
 #+:GCL (system:gbc-time 0)
     #+(or :sbcl :clisp :openmcl :lispworks)
     (if *fricas-load-libspad*
-        (let* ((ax-dir (|getEnv| "FRICAS"))
-               (spad-lib (concatenate 'string ax-dir "/lib/libspad.so")))
+        (let ((spad-lib (make-absolute-filename "/lib/libspad.so")))
             (format t "Checking for foreign routines~%")
-            (format t "FRICAS=~S~%" ax-dir)
+            (format t "FRICAS=~S~%" $spadroot)
             (format t "spad-lib=~S~%" spad-lib)
             (if (|fricas_probe_file| spad-lib)
                 (progn
@@ -301,7 +297,7 @@ After this function is called the image is clean and can be saved.
                     (|quiet_load_alien| spad-lib)
                     #+(or :sbcl :openmcl)
                     (fricas-lisp::init-gmp
-                        (concatenate 'string ax-dir "/lib/gmp_wrap.so"))
+                        (make-absolute-filename "/lib/gmp_wrap.so"))
                     #+(and :clisp :ffi)
                     (progn
                         (eval `(FFI:DEFAULT-FOREIGN-LIBRARY ,spad-lib))


### PR DESCRIPTION
The design purpose is to store "$FRICAS" into `$spadroot`.  And when `$FRICAS` changes, run `reroot`.  So all these `(|getEnv| "FRICAS")` should be changed to use `$spadroot` or `make-absolute-filename`.

(Putting here for review. Merge can be waited after release.)