### PR TITLE
use lisp function instead of shell commands for SBCL and ClozureCL

### DIFF
--- a/src/interp/nlib.lisp
+++ b/src/interp/nlib.lisp
@@ -321,9 +321,9 @@
 
 #+:sbcl
 (defun delete-directory (dirname)
-   #-:win32 (sb-ext::run-program "/bin/rm" (list "-r" dirname) :search t)
-   #+:win32 (obey (concat "rmdir /q /s " "\"" dirname "\""))
-  )
+  (if (sb-ext:delete-directory dirname :recursive t)
+      0
+      1))
 
 #+:cmu
 (defun delete-directory (dirname)
@@ -332,7 +332,9 @@
 
 #+:openmcl
 (defun delete-directory (dirname)
-   (ccl::run-program "rm" (list "-r" dirname)))
+  (if (ccl:delete-directory dirname)
+      0
+      1))
 
 #+:clisp
 (defun delete-directory (dirname)


### PR DESCRIPTION
This is useful when I try to do a pure lisp compile (aka don't use C functions, don't load shared library.)

Also this will works on windows as well, and performance is better.