### PR TITLE
Use String instead of Symbol in BOOT code, especially for printing functions

### DIFF
--- a/src/interp/apply.boot
+++ b/src/interp/apply.boot
@@ -203,7 +203,7 @@ compMapCond(op, mc, bindings, fnsel, e) ==
 
 compMapCond'([cexpr,fnexpr], op, dc, bindings, e) ==
   compMapCond''(cexpr, dc, e) => compMapCondFun(fnexpr,op,dc,bindings)
-  stackMessage ["not known that",'%b,dc,'%d,"has",'%b,cexpr,'%d]
+  stackMessage ['"not known that",'%b,dc,'%d,'"has",'%b,cexpr,'%d]
 
 compMapCond''(cexpr, dc, e) ==
   cexpr=true => true

--- a/src/interp/ax.boot
+++ b/src/interp/ax.boot
@@ -296,7 +296,7 @@ axFormatType(typeform) ==
                   ['PretendTo, axFormatType first args, axFormatType arg1type],
                      :[axFormatType a for a in rest args]]
       ['Apply, op, :[axFormatType a for a in args]]
-  error "unknown entry type"
+  error '"unknown entry type"
 
 pretendTo(a, t) == ['PretendTo, axFormatType a, axFormatType t]
 
@@ -344,7 +344,7 @@ axOpTran(name) ==
       name
    opOf name = 'Zero => '_0
    opOf name = 'One => '_1
-   error "bad op name"
+   error '"bad op name"
 
 axFormatOpSig(name, [result,:argtypes]) ==
    ['Declare, axOpTran name,
@@ -373,7 +373,7 @@ axFormatPred pred ==
    op = 'or  => ['Or,:axArglist]
    op = 'NOT => ['Not,:axArglist]
    op = 'not => ['Not,:axArglist]
-   error LIST("unknown predicate", pred)
+   error LIST('"unknown predicate", pred)
 
 
 -- This function is where we grow $augmentedType.
@@ -448,7 +448,7 @@ axFormatOp op ==
 
 addDefaults(catname, withform) ==
   withform isnt ['With, joins, ['Sequence,: oplist]] =>
-     error "bad category body"
+     error '"bad category body"
   null(defaults := getDefaultingOps catname) => withform
   defaultdefs := [decl for decl in defaults]
   ['With, joins,
@@ -456,7 +456,7 @@ addDefaults(catname, withform) ==
 
 makeDefaultDef(decl) ==
   decl isnt ['Declare, op, type] =>
-       error LIST("bad default definition", decl)
+       error LIST('"bad default definition", decl)
   $defaultFlag := true
   type is ['Apply, "->", args, result] =>
        ['Define, decl, ['Lambda, makeDefaultArgs args, result,
@@ -464,7 +464,7 @@ makeDefaultDef(decl) ==
   ['Define, ['Declare, op, type], 'dummyDefault]
 
 makeDefaultArgs args ==
-  args isnt ['Comma,:argl] => error "bad default argument list"
+  args isnt ['Comma,:argl] => error '"bad default argument list"
   ['Comma,: [['Declare,v,t] for v in $TriangleVariableList for t in argl]]
 
 getDefaultingOps catname ==

--- a/src/interp/bc-misc.boot
+++ b/src/interp/bc-misc.boot
@@ -36,7 +36,7 @@
 bcDrawIt2(ind,a,b) == STRCONC('"{}",ind,'"=",a,'"{}..",b,'"{}")
 
 bcIndefiniteIntegrate() ==
-  htInitPage("Indefinite Integration Basic Command",nil)
+  htInitPage('"Indefinite Integration Basic Command",nil)
   htMakePage '(
      (domainConditions
        (isDomain EM $EmptyMode)
@@ -63,7 +63,7 @@ bcIndefiniteIntegrateGen htPage ==
 
 
 bcDefiniteIntegrate() ==
-  htInitPage("Definite Integration Basic Command",nil)
+  htInitPage('"Definite Integration Basic Command",nil)
   htMakePage '(
      (domainConditions
        (isDomain EM $EmptyMode)
@@ -117,7 +117,7 @@ bcDefiniteIntegrateGen htPage ==
    STRCONC('"integrate(",integrand,'",",varpart,'")")
 
 bcSum() ==
-  htInitPage("Sum Basic Command",nil)
+  htInitPage('"Sum Basic Command",nil)
   htMakePage '(
     (domainConditions
        (isDomain EM $EmptyMode)
@@ -154,7 +154,7 @@ bcSumGen htPage ==
   bcGen STRCONC('"sum(",mand,'",",index,'" = ",first,'"..",last,'")")
 
 bcProduct() ==
-  htInitPage("Product Basic Command",nil)
+  htInitPage('"Product Basic Command",nil)
   htMakePage '(
     (domainConditions
        (isDomain EM $EmptyMode)
@@ -179,7 +179,7 @@ bcProductGen htPage ==
   bcGen STRCONC('"product(",mand,'",",index,'",",first,'",",last,'")")
 
 bcDifferentiate() ==
-  htInitPage("Differentiate Basic Command",nil)
+  htInitPage('"Differentiate Basic Command",nil)
   htMakePage '(
     (domainConditions
        (isDomain EM $EmptyMode)

--- a/src/interp/bc-solve.boot
+++ b/src/interp/bc-solve.boot
@@ -179,7 +179,7 @@ bcCreateVariableString(i) ==
    STRCONC('"x",STRINGIMAGE i)
 
 bcMakeUnknowns(number)==
-   concatenateStringList([STRCONC(bcCreateVariableString(i)," ")
+   concatenateStringList([STRCONC(bcCreateVariableString(i),'" ")
                             for i in 1..number])
 
 bcMakeEquations(i,number)==

--- a/src/interp/br-con.boot
+++ b/src/interp/br-con.boot
@@ -70,15 +70,15 @@ conPageConEntry entry ==
 kxPage(htPage,name) == downlink name
 
 kdPageInfo(name,abbrev,nargs,conform,signature,file?) ==
-  htSay("{\sf ",name,'"}")
-  if abbrev ~= name then bcHt [" has abbreviation ",abbrev]
+  htSay('"{\sf ",name,'"}")
+  if abbrev ~= name then bcHt ['" has abbreviation ",abbrev]
   if file? then bcHt ['" is a source file."]
   if nargs = 0 then (if abbrev ~= name then bcHt '".")
     else
       if abbrev ~= name then bcHt '" and"
       bcHt
         nargs = 1 => '" takes one argument:"
-        [" takes ",STRINGIMAGE nargs," arguments:"]
+        ['" takes ",STRINGIMAGE nargs,'" arguments:"]
   htSayStandard '"\indentrel{2}"
   if nargs > 0 then kPageArgs(conform,signature)
   htSayStandard '"\indentrel{-2}"
@@ -769,7 +769,7 @@ dbShowCons1(htPage,cAlist,key) ==
     key = 'parameters => bcConTable REMDUP ASSOCLEFT cAlist
     key = 'kinds => dbShowConsKinds cAlist
   dbConsExposureMessage()
-  htSayStandard("\endscroll ")
+  htSayStandard('"\endscroll ")
   dbPresentCons(page,kind,key)
   htShowPageNoScroll()
 

--- a/src/interp/br-op1.boot
+++ b/src/interp/br-op1.boot
@@ -153,7 +153,7 @@ dbShowOp1(htPage,opAlist,which,key) ==
   FUNCALL(fn,page,opAlist,which,data) --apply branch function
   if $atLeastOneUnexposed then
       htSay '"{\em *} = unexposed"
-  htSayStandard("\endscroll ")
+  htSayStandard('"\endscroll ")
   dbPresentOps(page,which,branch)
   htShowPageNoScroll()
 

--- a/src/interp/br-saturn.boot
+++ b/src/interp/br-saturn.boot
@@ -285,7 +285,7 @@ kPage(line, options) == --any cat, dom, package, default package
   if name=abbrev then abbrev := asyAbbreviation(conname,nargs)
   page := htInitPageNoHeading(nil)
   htAddHeading heading
-  htSayStandard("\beginscroll ")
+  htSayStandard('"\beginscroll ")
   htpSetProperty(page,'isFile,true)
   htpSetProperty(page,'parts,parts)
   htpSetProperty(page,'heading,heading)
@@ -299,7 +299,7 @@ kPage(line, options) == --any cat, dom, package, default package
   dbShowConsDoc1(page,conform,nil)
   if kind ~= 'category and nargs > 0 then addParameterTemplates(page,conform)
   if $atLeastOneUnexposed then htSay '"\newline{}{\em *} = unexposed"
-  htSayStandard("\endscroll ")
+  htSayStandard('"\endscroll ")
   kPageContextMenu page
   htShowPageNoScroll()
 
@@ -337,7 +337,7 @@ kPageContextMenu page ==
   if kind ~= '"category" then
     htSay '"}{"
     if not asharpConstructorName? conname
-    then  htMakePage [['bcLinks,["Search Path",'"",'ksPage,nil]]]
+    then  htMakePage [['bcLinks,['"Search Path",'"",'ksPage,nil]]]
     else htSay '"{\em Search Path}"
   if kind ~= '"category" then
     htSay '"}{"
@@ -400,8 +400,8 @@ dbPresentCons(htPage,kind,:exclusions) ==
   htEndTable()
 
 htFilterPage(htPage,args) ==
-  htInitPage("Filter String",htCopyProplist htPage)
-  htSay "\centerline{Enter filter string (use {\em *} for wild card):}"
+  htInitPage('"Filter String",htCopyProplist htPage)
+  htSay '"\centerline{Enter filter string (use {\em *} for wild card):}"
   htSay '"\centerline{"
   htMakePage [['bcStrings, [50,'"",'filter,'EM]]]
   htSay '"}\vspace{1}\centerline{"
@@ -692,7 +692,7 @@ displayDomainOp(htPage,which,origin,op,sig,predicate,
             if IFCAR coSig and t ~= '(Type)
               then htMakePage [['bcLinks,[a,'"",'kArgPage,a]]]
               else htSayList(['"{\em ", form2HtString(a), '"}"])
-            htSay ", "
+            htSay '", "
             coSig := IFCDR coSig
             htSayValue t
             htSayIndentRel2(-15, true)
@@ -736,7 +736,7 @@ displayDomainOp(htPage,which,origin,op,sig,predicate,
       htSayIndentRel2(-15, true)
     for [d,key,:t] in $whereList | d ~= "$" repeat
       htSayIndentRel2(15, count > 1)
-      htSayList(["{\em ", d, "} is "])
+      htSayList(['"{\em ", d, '"} is "])
       htSayConstructor(key, sublisFormal(IFCDR conform, t))
       htSayIndentRel2(-15, count > 1)
   -----------------------------------------------------------
@@ -802,7 +802,7 @@ htEndMenu(kind) ==
   htSayStandard '"\endmenu "
 
 htSayConstructorName(nameShown, name) ==
-    htSayStandard ["\lispdownlink{",nameShown,'"}{(|conPage| '|",name,'"|)}"]
+    htSayStandard ['"\lispdownlink{",nameShown,'"}{(|conPage| '|",name,'"|)}"]
 
 --------------------> NEW DEFINITION (see ht-util.boot)
 htAddHeading(title) ==

--- a/src/interp/br-search.boot
+++ b/src/interp/br-search.boot
@@ -283,7 +283,7 @@ mkGrepPattern1(x,:options) == --called by mkGrepPattern (and grepConstructName?)
         while ((i := f + 1) <= max) and (f := charPosition(char,s,i))]
     charPosition(c,t,startpos) ==  --honors underscores
       n := SIZE t
-      if startpos < 0 or startpos > n then error "index out of range"
+      if startpos < 0 or startpos > n then error '"index out of range"
       k:= startpos
       for i in startpos .. n-1 while c ~= ELT(t,i)
         or i > startpos and ELT(t,i-1) = '__ repeat  (k := k+1)

--- a/src/interp/buildom.boot
+++ b/src/interp/buildom.boot
@@ -252,7 +252,7 @@ createEnum(sym, dom) ==
   val := -1
   for v in args for i in 0.. repeat
      sym=v => return(val:=i)
-  val<0 => error ["Cannot coerce",sym,"to",["Enumeration",:args]]
+  val<0 => error ['"Cannot coerce",sym,'"to",['"Enumeration",:args]]
   val
 
 --% INSTANTIATORS

--- a/src/interp/c-doc.boot
+++ b/src/interp/c-doc.boot
@@ -695,7 +695,7 @@ checkDecorate u ==
         if spadflag = count then spadflag := false
       else if not mathSymbolsOk and member(x,'("+" "*" "=" "==" "->")) then
         if $checkingXmptex? then
-          checkDocError ["Symbol ",x,'" appearing outside \spad{}"]
+          checkDocError ['"Symbol ",x,'" appearing outside \spad{}"]
 
     acc :=
       x = '"\end{verbatim}" =>
@@ -945,7 +945,7 @@ checkBeginEnd u ==
           and not
             (substring?('"\radiobox",x,0) or substring?('"\inputbox",x,0))=>
              --allow 0 argument guys to pass through
-              checkDocError ["Unexpected HT command: ",x]
+              checkDocError ['"Unexpected HT command: ",x]
       x = '"\beginitems" =>
         beginEndStack := ["items",:beginEndStack]
       x = '"\begin" =>
@@ -1169,7 +1169,7 @@ checkDecorateForHt u ==
         if spadflag = count then spadflag := false
       else if not spadflag and member(x,'("+" "*" "=" "==" "->")) then
         if $checkingXmptex? then
-          checkDocError ["Symbol ",x,'" appearing outside \spad{}"]
+          checkDocError ['"Symbol ",x,'" appearing outside \spad{}"]
       x = '"$" or x = '"%" => checkDocError ['"Unescaped ",x]
     u := rest u
   u

--- a/src/interp/c-util.boot
+++ b/src/interp/c-util.boot
@@ -81,9 +81,9 @@ displayComp level ==
   sayBrightly ['"****** level",'%b,level,'%d,'" ******"]
   [$x, $m, $f, $exitModeStack] := $s.(level - 1)
   ($X:=$x;$M:=$m;$F:=$f)
-  SAY("$x:= ",$x)
-  SAY("$m:= ",$m)
-  SAY "$f:="
+  SAY('"$x:= ",$x)
+  SAY('"$m:= ",$m)
+  SAY '"$f:="
   limited_print1_stdout($f)
   nil
 
@@ -190,7 +190,7 @@ intersectionContour(c, c', ce) ==
       pair:= assoc("mode",p) =>
         pair':= assoc("mode",p') =>
           m'' := unifiable(rest pair, rest pair', ce) => LIST ["mode", :m'']
-          stackSemanticError(['%b,$var,'%d,"has two modes: "],nil)
+          stackSemanticError(['%b,$var,'%d,'"has two modes: "],nil)
        --stackWarning ("mode for",'%b,$var,'%d,"introduced conditionally")
         LIST ["conditionalmode",:rest pair]
         --LIST pair
@@ -228,8 +228,8 @@ addContour(c,E is [cur,:tail]) ==
                      --check for conflicts with earlier mode
                      if vv:=LASSOC("mode",e) then
                         if v ~=vv then
-                          stackWarning ["The conditional modes ",
-                                     v," and ",vv," conflict"]
+                          stackWarning ['"The conditional modes ",
+                                     v,'" and ",vv,'" conflict"]
         LIST c
 
 makeCommonEnvironment(e,e') ==
@@ -257,10 +257,10 @@ printEnv E ==
       SAY('"******CONTOUR ",j,'", LEVEL ",i,'":******")
       for z in y repeat
         TERPRI()
-        SAY("Properties Of: ",first z)
+        SAY('"Properties Of: ",first z)
         for u in rest z repeat
           PRIN0 first u
-          printString ": "
+          printString '": "
           PRETTYPRINT tran(rest u,first u) where
             tran(val,prop) ==
               prop="value" => DROP(-1,val)
@@ -272,10 +272,10 @@ prEnv E ==
       SAY('"******CONTOUR ",j,'", LEVEL ",i,'":******")
       for z in y | not LASSOC("modemap",rest z) repeat
         TERPRI()
-        SAY("Properties Of: ",first z)
+        SAY('"Properties Of: ",first z)
         for u in rest z repeat
           PRIN0 first u
-          printString ": "
+          printString '": "
           PRETTYPRINT tran(rest u,first u) where
             tran(val,prop) ==
               prop="value" => DROP(-1,val)
@@ -290,7 +290,7 @@ prModemaps E ==
           listOfOperatorsSeenSoFar:= [first z,:listOfOperatorsSeenSoFar]
           TERPRI()
           PRIN0 first z
-          printString ": "
+          printString '": "
           PRETTYPRINT modemap
 
 prTriple T ==
@@ -507,11 +507,11 @@ printAny x == if atom x then printString x else PRIN0 x
 printSignature(before,op,[target,:argSigList]) ==
   printString before
   printString op
-  printString ": _("
+  printString '": _("
   if argSigList then
     printAny first argSigList
-    for m in rest argSigList repeat (printString ","; printAny m)
-  printString "_) -> "
+    for m in rest argSigList repeat (printString '","; printAny m)
+  printString '"_) -> "
   printAny target
   TERPRI()
 
@@ -555,7 +555,7 @@ extendsCategoryForm(domain, form, form', e) ==
                               for x in l]
   form is ["CATEGORY",.,:l] =>
     member(form',l) or
-      stackWarning ["not known that ",form'," is of mode ",form] or true
+      stackWarning ['"not known that ",form','" is of mode ",form] or true
   isCategoryForm(form) =>
           --Constructs the associated vector
     formVec := (compMakeCategoryObject(form, e)).expr
@@ -624,7 +624,7 @@ old2NewModemaps x ==
   x
 
 traceUp() ==
-  atom $x => sayBrightly "$x is an atom"
+  atom $x => sayBrightly '"$x is an atom"
   for y in rest $x repeat
     u:= comp(y,$EmptyMode,$f) =>
       sayBrightly [y,'" ==> mode",'%b,u.mode,'%d]
@@ -637,25 +637,25 @@ _?m x ==
 traceDown() ==
   mmList:= getFormModemaps($x,$f) =>
     for mm in mmList repeat if u:= qModemap mm then return u
-  sayBrightly "no modemaps for $x"
+  sayBrightly '"no modemaps for $x"
 
 qModemap mm ==
   sayBrightly ['%b,"modemap",'%d,:formatModemap mm]
   [[dc,target,:sl],[pred,:.]]:= mm
   and/[qArg(a,m) for a in rest $x for m in sl] => target
-  sayBrightly ['%b,"fails",'%d,'%l]
+  sayBrightly ['%b,'"fails",'%d,'%l]
 
 qArg(a,m) ==
   yesOrNo:=
     u:= comp(a,m,$f) => "yes"
     "no"
-  sayBrightly [a," --> ",m,'%b,yesOrNo,'%d]
+  sayBrightly [a,'" --> ",m,'%b,yesOrNo,'%d]
   yesOrNo="yes"
 
 _?comp x ==
   msg:=
     u:= comp(x,$EmptyMode,$f) =>
-      [MAKESTRING "compiles to mode",'%b,u.mode,'%d]
+      [MAKESTRING '"compiles to mode",'%b,u.mode,'%d]
     nil
   sayBrightly msg
 
@@ -668,12 +668,12 @@ _?properties x == displayProplist(x,getProplist(x,$f))
 _?value x == displayProplist(x,[["value",:get(x,"value",$f)]])
 
 displayProplist(x,alist) ==
-  sayBrightly ["properties of",'%b,x,'%d,":"]
+  sayBrightly ['"properties of",'%b,x,'%d,'":"]
   fn alist where
     fn alist ==
       alist is [[prop,:val],:l] =>
         if prop="value" then val:= [val.expr,val.mode,'"..."]
-        sayBrightly ["   ",'%b,prop,'%d,": ",val]
+        sayBrightly ['"   ",'%b,prop,'%d,'": ",val]
         fn deleteAssoc(prop,l)
 
 displayModemaps E ==

--- a/src/interp/category.boot
+++ b/src/interp/category.boot
@@ -36,23 +36,23 @@
 Category() == nil --sorry to say, this hack is needed by isCategoryType
 
 CategoryPrint(D) ==
-  SAY "--------------------------------------"
-  SAY "Name (and arguments) of category:"
+  SAY '"--------------------------------------"
+  SAY '"Name (and arguments) of category:"
   PRETTYPRINT D.(0)
-  SAY "operations:"
+  SAY '"operations:"
   PRETTYPRINT D.(1)
-  SAY "attributes:"
+  SAY '"attributes:"
   PRETTYPRINT D.2
-  SAY "This is a sub-category of"
+  SAY '"This is a sub-category of"
   PRETTYPRINT first D.4
   for u in CADR D.4 repeat
-    SAY("This has an alternate view: slot ",rest u," corresponds to ",first u)
+    SAY('"This has an alternate view: slot ",rest u,'" corresponds to ",first u)
   for u in CADDR D.4 repeat
-    SAY("This has a local domain: slot ",rest u," corresponds to ",first u)
+    SAY('"This has a local domain: slot ",rest u,'" corresponds to ",first u)
   for j in 6..MAXINDEX D repeat
     u:= D.j
-    null u => SAY "another domain"
-    atom first u => SAY("Alternate View corresponding to: ",u)
+    null u => SAY '"another domain"
+    atom first u => SAY('"Alternate View corresponding to: ",u)
     PRETTYPRINT u
 
 -- create a new category vector

--- a/src/interp/clam.boot
+++ b/src/interp/clam.boot
@@ -197,31 +197,31 @@ displayHashtable x ==
 cacheStats() ==
   for [fn,kind,:u] in $clamList repeat
     not MEMQ('count,u) =>
-      sayBrightly ["%b",fn,"%d","does not keep reference counts"]
+      sayBrightly ["%b",fn,"%d",'"does not keep reference counts"]
     INTEGERP kind => reportCircularCacheStats(fn,kind)
     kind = 'hash => reportHashCacheStats fn
-    sayBrightly ["Unknown cache type for","%b",fn,"%d"]
+    sayBrightly ['"Unknown cache type for","%b",fn,"%d"]
 
 reportCircularCacheStats(fn,n) ==
   infovec := GET(fn, 'cacheInfo)
   circList:= eval infovec.cacheName
   numberUsed :=
     +/[1 for i in 1..n for x in circList while x isnt [='_$failed,:.]]
-  sayBrightly ["%b",fn,"%d","has","%b",numberUsed,"%d","/ ",n," values cached"]
+  sayBrightly ["%b",fn,"%d",'"has","%b",numberUsed,"%d",'"/ ",n,'" values cached"]
   displayCacheFrequency mkCircularCountAlist(circList,n)
   TERPRI()
 
 displayCacheFrequency al ==
   al := NREVERSE SORTBY('CAR,al)
-  sayBrightlyNT "    #hits/#occurrences: "
-  for [a,:b] in al repeat sayBrightlyNT [a,"/",b,"  "]
+  sayBrightlyNT '"    #hits/#occurrences: "
+  for [a,:b] in al repeat sayBrightlyNT [a,'"/",b,'"  "]
   TERPRI()
 
 mkCircularCountAlist(cl,len) ==
   for [x,count,:.] in cl for i in 1..len while x ~= '_$failed repeat
     u:= assoc(count,al) => RPLACD(u,1 + CDR u)
     if INTEGERP $reportFavoritesIfNumber and count >= $reportFavoritesIfNumber then
-      sayBrightlyNT ["   ",count,"  "]
+      sayBrightlyNT ['"   ",count,'"  "]
       pp x
     al:= [[count,:1],:al]
   al
@@ -305,21 +305,21 @@ assocCacheShiftCount(x,al,fn) ==
 
 clamStats() ==
   for [op,kind,:.] in $clamList repeat
-    cacheVec := GET(op, 'cacheInfo) or systemErrorHere "clamStats"
+    cacheVec := GET(op, 'cacheInfo) or systemErrorHere '"clamStats"
     prefix:=
       $reportCounts~= true => nil
       hitCounter := INTERNL1(op, '";hit")
       callCounter := INTERNL1(op, '";calls")
-      res:= ["%b",eval hitCounter,"/",eval callCounter,"%d","calls to "]
+      res:= ["%b",eval hitCounter,'"/",eval callCounter,"%d",'"calls to "]
       SET(hitCounter,0)
       SET(callCounter,0)
       res
     postString:=
       cacheValue:= eval cacheVec.cacheName
-      kind = 'hash => [" (","%b",HASH_-TABLE_-COUNT cacheValue,"%d","entries)"]
+      kind = 'hash => ['" (","%b",HASH_-TABLE_-COUNT cacheValue,"%d",'"entries)"]
       empties:= numberOfEmptySlots eval cacheVec.cacheName
       empties = 0 => nil
-      [" (","%b",kind-empties,"/",kind,"%d","slots used)"]
+      ['" (","%b",kind-empties,'"/",kind,"%d",'"slots used)"]
     sayBrightly
       [:prefix,op,:postString]
 
@@ -450,9 +450,9 @@ globalHashtableStats(x,sortFn) ==
       not INTEGERP n =>   keyedSystemError("S2GE0013",[x])
       argList1:= [constructor2ConstructorForm x for x in argList]
       reportList:= [[n,key,argList1],:reportList]
-  sayBrightly ["%b","  USE  NAME ARGS","%d"]
+  sayBrightly ["%b",'"  USE  NAME ARGS","%d"]
   for [n,fn,args] in NREVERSE SORTBY(sortFn,reportList) repeat
-    sayBrightlyNT [:rightJustifyString(n,6),"  ",fn,": "]
+    sayBrightlyNT [:rightJustifyString(n,6),'"  ",fn,'": "]
     pp args
 
 constructor2ConstructorForm x ==

--- a/src/interp/compiler.boot
+++ b/src/interp/compiler.boot
@@ -101,12 +101,12 @@ compOrCroak1(x,m,e,compFn) ==
       errorMessage:=
         if $compErrorMessageStack
            then first $compErrorMessageStack
-           else "unspecified error"
+           else '"unspecified error"
       $scanIfTrue =>
         stackSemanticError(errorMessage,mkErrorExpr $level)
         ["failedCompilation",m,e]
       displaySemanticErrors()
-      SAY("****** comp fails at level ",$level," with expression: ******")
+      SAY('"****** comp fails at level ",$level,'" with expression: ******")
       displayComp $level
       userError errorMessage
 
@@ -180,8 +180,8 @@ compLambda(x is ["+->", vl, body], m, e) ==
                  ress := compAtSign(["@", ["+->", arg1, body],
                                   ["Mapping", target, :sig1]], m, e)
                  ress
-             stackAndThrow ["compLambda: malformed argument list", x]
-        stackAndThrow ["compLambda: malformed argument list", x]
+             stackAndThrow ['"compLambda: malformed argument list", x]
+        stackAndThrow ['"compLambda: malformed argument list", x]
     nil
 
 getFreeList(u, bound, free, e) ==
@@ -257,11 +257,11 @@ compWithMappingMode1(x, m is ["Mapping", m', :sl], oldE, $formalArgList) ==
       vl :=
          IDENTP(vl) => [vl]
          LISTP(vl) and (and/[SYMBOLP(v) for v in vl])=> vl
-         stackAndThrow ["bad +-> arguments:", vl]
+         stackAndThrow ['"bad +-> arguments:", vl]
       $formalArgList := [:vl, :$formalArgList]
       #sl ~= #vl =>
          stackAndThrow [_
-           "number of arguments to +-> does not match, expected:", #sl]
+           '"number of arguments to +-> does not match, expected:", #sl]
       x := nx
   else
       vl:= take(#sl,$FormalMapVariableList)
@@ -393,13 +393,13 @@ compSymbol(s,m,e) ==
     if not member(s,$formalArgList) and not MEMQ(s,$FormalMapVariableList) and
       not isFunction(s,e) and null ($compForModeIfTrue=true) then errorRef s
     [s,m',e] --s is a declared argument
-  MEMQ(s,$FormalMapVariableList) => stackMessage ["no mode found for",s]
+  MEMQ(s,$FormalMapVariableList) => stackMessage ['"no mode found for",s]
   not isFunction(s,e) => errorRef s
 
 convertOrCroak(T,m) ==
   u:= convert(T,m) => u
-  userError ["CANNOT CONVERT: ",T.expr,"%l"," OF MODE: ",T.mode,"%l",
-    " TO MODE: ",m,"%l"]
+  userError ['"CANNOT CONVERT: ",T.expr,"%l",'" OF MODE: ",T.mode,"%l",
+    '" TO MODE: ",m,"%l"]
 
 convert(T,m) ==
   coerce(T,resolve(T.mode,m) or return nil)
@@ -418,7 +418,7 @@ hasType(x,e) ==
 compForm(form,m,e) ==
   T:=
     compForm1(form,m,e) or compArgumentsAndTryAgain(form,m,e) or return
-      stackMessageIfNone ["cannot compile","%b",form,"%d"]
+      stackMessageIfNone ['"cannot compile","%b",form,"%d"]
   T
 
 compArgumentsAndTryAgain(form is [.,:argl],m,e) ==
@@ -439,7 +439,7 @@ outputComp(x,e) ==
         for x in argl]], $OutputForm, e]
   (v:= get(x,"value",e)) and (v.mode is ['Union,:l]) =>
     [['coerceUn2E, x, v.mode], $OutputForm, e]
-  SAY ["outputComp strange x ", x]
+  SAY ['"outputComp strange x ", x]
   nil
 
 compSel1(domain, op, argl, m, e) ==
@@ -485,11 +485,11 @@ compForm1(form is [op,:argl],m,e) ==
           arg := first(argl)
           u := comp(arg, $String, e) =>
               [[op, u.expr], m, e]
-          SAY ["compiling call to error ", argl]
+          SAY ['"compiling call to error ", argl]
           u := outputComp(arg, e) =>
               [[op, ['LIST, ['QUOTE, 'mathprint], u.expr]], m, e]
           nil
-      SAY ["compiling call to error ", argl]
+      SAY ['"compiling call to error ", argl]
       nil
   op is ["Sel", domain, op'] => compSel1(domain, op', argl, m, e)
 
@@ -544,14 +544,14 @@ getFormModemaps(form is [op,:argl],e) ==
   nargs:= #argl
   finalModemapList:= [mm for (mm:= [[.,.,:sig],:.]) in modemapList | #sig=nargs]
   modemapList and null finalModemapList =>
-    stackMessage ["no modemap for","%b",op,"%d","with ",nargs," arguments"]
+    stackMessage ['"no modemap for","%b",op,"%d",'"with ",nargs,'" arguments"]
   finalModemapList
 
 eltModemapFilter(name,mmList,e) ==
   isConstantId(name,e) =>
     l:= [mm for mm in mmList | mm is [[.,.,.,sel,:.],:.] and sel=name] => l
             -- setelt! has extra parameter
-    stackMessage ["selector variable: ",name," is undeclared and unbound"]
+    stackMessage ['"selector variable: ",name,'" is undeclared and unbound"]
     nil
   mmList
 
@@ -608,7 +608,7 @@ setqSingle(id,val,m,E) ==
         (T:= comp(val,$EmptyMode,E)) and getmode(T.mode,E) =>
           assignError(val,T.mode,id,m'')
   m'' = $EmptyMode and T.mode = $EmptyMode =>
-      stackMessage ["No mode in assignment to: ", id]
+      stackMessage ['"No mode in assignment to: ", id]
   finish_setq_single(T, m, id, val, currentProplist)
 
 finish_setq_single(T, m, id, val, currentProplist) ==
@@ -617,8 +617,8 @@ finish_setq_single(T, m, id, val, currentProplist) ==
   e':= (PAIRP id => e'; addBinding(id,newProplist,e'))
   if isDomainForm(val,e') then
     if isDomainInScope(id,e') then
-      stackWarning ["domain valued variable","%b",id,"%d",
-        "has been reassigned within its scope"]
+      stackWarning ['"domain valued variable","%b",id,"%d",
+        '"has been reassigned within its scope"]
     e':= augModemapsFromDomain1(id,val,e')
       --all we do now is to allocate a slot number for lhs
       --e.g. the LET form below will be changed by putInLocalDomainReferences
@@ -639,20 +639,20 @@ saveLocVarsTypeDecl(x, id, e) ==
         typeDecl := ASSOC(id, $locVarsTypes)
         null typeDecl =>
             if null t then
-                SAY("Local variable ", id, " lacks type.")
+                SAY('"Local variable ", id, '" lacks type.")
             else $locVarsTypes := ACONS(id, t, $locVarsTypes)
         t' := CDR(typeDecl)
         not EQUAL(t, t') =>
             if not null t' then
-                SAY("Local variable ", id, " type redefined: ", t, " to ", t')
+                SAY('"Local variable ", id, '" type redefined: ", t, '" to ", t')
             RPLACD(typeDecl, t)
 
 assignError(val,m',form,m) ==
   message:=
     val =>
-      ["CANNOT ASSIGN: ",val,"%l","   OF MODE: ",m',"%l","   TO: ",form,"%l",
-        "   OF MODE: ",m]
-    ["CANNOT ASSIGN: ",val,"%l","   TO: ",form,"%l","   OF MODE: ",m]
+      ['"CANNOT ASSIGN: ",val,"%l",'"   OF MODE: ",m',"%l",'"   TO: ",form,"%l",
+        '"   OF MODE: ",m]
+    ['"CANNOT ASSIGN: ",val,"%l",'"   TO: ",form,"%l",'"   OF MODE: ",m]
   stackMessage message
 
 MKPROGN(l) == MKPF(l, "PROGN")
@@ -690,9 +690,9 @@ setqMultiple(nameList,val,m,e) ==
         t is ["Record",:l] => [[name,:mode] for [":",name,mode] in l]
         comp(t,$EmptyMode,e) is [.,["RecordCategory",:l],.] =>
           [[name,:mode] for [":",name,mode] in l]
-        stackMessage ["no multiple assigns to mode: ",t]
+        stackMessage ['"no multiple assigns to mode: ",t]
   #nameList~=#selectorModePairs =>
-    stackMessage [val," must decompose into ",#nameList," components"]
+    stackMessage [val,'" must decompose into ",#nameList,'" components"]
   -- 3 generate code; return
   assignList:=
     [([.,.,e]:= compSetq1(x,["elt",g,y],z,e) or return "failed").expr
@@ -702,8 +702,8 @@ setqMultiple(nameList,val,m,e) ==
 
 setqMultipleExplicit(nameList,valList,m,e) ==
   #nameList~=#valList =>
-    stackMessage ["Multiple assignment error; # of items in: ",nameList,
-      "must = # in: ",valList]
+    stackMessage ['"Multiple assignment error; # of items in: ",nameList,
+      '"must = # in: ",valList]
   gensymList:= [genVariable() for name in nameList]
   assignList:=
              --should be fixed to declare genVar when possible
@@ -747,7 +747,7 @@ compConstruct(form is ["construct", :l], m, e) ==
 
 compQuote(expr is [QUOTE, e1], m, e) ==
   SYMBOLP(e1) => [expr, ["Symbol"], e]
-  stackAndThrow ["Strange argument to QUOTE", expr]
+  stackAndThrow ['"Strange argument to QUOTE", expr]
   -- [expr,m,e]
 
 compList(l,m is ["List",mUnder],e) ==
@@ -773,7 +773,7 @@ compMacro(form,m,e) ==
     formatUnabbreviated rhs
   sayBrightly ['"   processing macro definition",'%b,
     :formatUnabbreviated lhs,'" ==> ",:prhs,'%d]
-  ATOM(lhs) => userError("Malformed macro definition")
+  ATOM(lhs) => userError('"Malformed macro definition")
   nrhs :=
       (margs := rest(lhs)) => [rhs, :margs]
       [rhs]
@@ -828,7 +828,7 @@ replaceExitEtc(x,tag,opFlag,opMode) ==
 comp_try(["try", expr, catcher, finallizer], m, e) ==
     $exitModeStack : local := [m, :$exitModeStack]
     if catcher then
-        stackAndThrow ["comp_try: catch unimplemented"]
+        stackAndThrow ['"comp_try: catch unimplemented"]
     ([c1, m1, .] := comp(expr, m, e)) or return nil
     ([c2, ., .] := comp(finallizer, $EmptyMode, e)) or return nil
     [["finally", c1, c2], m1, e]
@@ -849,13 +849,13 @@ compExit(["exit",level,x],m,e) ==
   [x',m',e']:=
     u:=
       comp(x,m1,e) or return
-        stackMessageIfNone ["cannot compile exit expression",x,"in mode",m1]
+        stackMessageIfNone ['"cannot compile exit expression",x,'"in mode",m1]
   modifyModeStack(m',index)
   [["TAGGEDexit",index,u],m,e]
 
 modifyModeStack(m,index) ==
   $reportExitModeStack =>
-    SAY("exitModeStack: ",COPY $exitModeStack," ====> ",
+    SAY('"exitModeStack: ",COPY $exitModeStack,'" ====> ",
       ($exitModeStack.index:= resolve(m,$exitModeStack.index); $exitModeStack))
   $exitModeStack.index:= resolve(m,$exitModeStack.index)
 
@@ -870,7 +870,7 @@ compLeave(["leave",level,x],m,e) ==
 compReturn(["return", x], m, e) ==
   ns := #$exitModeStack
   ns = $currentFunctionLevel =>
-    stackSemanticError(["the return before","%b",x,"%d","is unnecessary"],nil)
+    stackSemanticError(['"the return before","%b",x,"%d",'"is unnecessary"],nil)
     nil
   index := MAX(0, ns - $currentFunctionLevel - 1)
   $returnMode:= resolve($exitModeStack.index,$returnMode)
@@ -963,7 +963,7 @@ canReturn(expr,level,exitCount,ValueFlag) ==  --SPAD: exit and friends
   op="IF" =>
     expr is [.,a,b,c]
     if not canReturn(a,0,0,true) then
-      SAY "IF statement can not cause consequents to be executed"
+      SAY '"IF statement can not cause consequents to be executed"
       pp expr
     canReturn(a,level,exitCount,nil) or canReturn(b,level,exitCount,ValueFlag)
       or canReturn(c,level,exitCount,ValueFlag)
@@ -1095,14 +1095,14 @@ unknownTypeError name ==
   name:=
     name is [op,:.] => op
     name
-  stackSemanticError(["%b",name,"%d","is not a known type"],nil)
+  stackSemanticError(["%b",name,"%d",'"is not a known type"],nil)
 
 compPretend(["pretend",x,t],m,e) ==
   e:= addDomain(t,e)
   T:= comp(x,t,e) or comp(x,$EmptyMode,e) or return nil
-  if T.mode=t then warningMessage:= ["pretend",t," -- should replace by @"]
+  if T.mode=t then warningMessage:= ['"pretend",t,'" -- should replace by @"]
   if opOf(T.mode) = 'Union and opOf(m) ~= 'Union then
-     stackWarning(["cannot pretend ",x," of mode ",T.mode," to mode ",m])
+     stackWarning(['"cannot pretend ",x,'" of mode ",T.mode,'" to mode ",m])
   T:= [T.expr,t,T.env]
   T':= coerce(T,m) => (if warningMessage then stackWarning warningMessage; T')
 
@@ -1135,8 +1135,8 @@ coerce(T,m) ==
       -- from compFormWithModemap to filter through the modemaps
   stackMessage fn(T.expr,T.mode,m) where
     fn(x,m1,m2) ==
-      ["Cannot coerce","%b",x,"%d","%l","      of mode","%b",m1,"%d","%l",
-        "      to mode","%b",m2,"%d"]
+      ['"Cannot coerce","%b",x,"%d","%l",'"      of mode","%b",m1,"%d","%l",
+        '"      to mode","%b",m2,"%d"]
 
 coerceEasy(T,m) ==
   m=$EmptyMode => T
@@ -1279,8 +1279,8 @@ autoCoerceByModemap([x,source,e],target) ==
     (y:= get(x,"condition",e)) and (or/[u is ["case",., =target] for u in y])
        => [["call",fn,x],target,e]
     x="$fromCoerceable$" => nil
-    stackMessage ["cannot coerce: ",x,"%l","      of mode: ",source,"%l",
-      "      to: ",target," without a case statement"]
+    stackMessage ['"cannot coerce: ",x,"%l",'"      of mode: ",source,"%l",
+      '"      to: ",target,'" without a case statement"]
   [["call",fn,x],target,e]
 
 --% Very old resolve
@@ -1376,7 +1376,7 @@ compileSpad2Cmd args ==
         [optname,:optargs] := opt
         fullopt := selectOptionLC(optname,optList,nil)
 
-        fullopt = 'new         => error "Internal error: compileSpad2Cmd got )new"
+        fullopt = 'new         => error '"Internal error: compileSpad2Cmd got )new"
         fullopt = 'old         => NIL     -- no opt
 
         fullopt = 'library     => fun.1 := 'lib
@@ -1394,7 +1394,7 @@ compileSpad2Cmd args ==
         fullopt = 'functions   =>
             null optargs =>
               throwKeyedMsg("S2IZ0037",['")functions"])
-            throwKeyedMsg(")functions unsupported", [])
+            throwKeyedMsg('")functions unsupported", [])
         fullopt = 'constructor =>
             null optargs =>
               throwKeyedMsg("S2IZ0037",['")constructor"])

--- a/src/interp/define.boot
+++ b/src/interp/define.boot
@@ -124,8 +124,8 @@ macroExpand(x,e) ==   --not worked out yet
       u := get(x, 'macro, e) =>
           null(rest(u)) =>
               macroExpand(first u, e)
-          SAY(["u =", u])
-          userError("macro call needs arguments")
+          SAY(['"u =", u])
+          userError('"macro call needs arguments")
       x
   x is ['DEF, lhs, sig, rhs] =>
     ['DEF, macroExpand(lhs, e), macroExpandList(sig, e), macroExpand(rhs, e)]
@@ -137,7 +137,7 @@ macroExpand(x,e) ==   --not worked out yet
               null(margs) => [macroExpand(u, e), :macroExpandList(args, e)]
               #args = #margs =>
                   macroExpand(SUBLISLIS(args, margs, u), e)
-              userError("invalid macro call, #args ~= #margs")
+              userError('"invalid macro call, #args ~= #margs")
           [op, :macroExpandList(args, e)]
       macroExpandList(x,e)
   macroExpandList(x,e)
@@ -477,12 +477,12 @@ displayMissingFunctions() ==
     sayBrightly ['%l,:bright '"  Missing Local Functions:"]
     for [op,sig] in loc for i in 1.. repeat
       sayBrightly ['"      [",i,'"]",:bright op,
-        ": ",:formatUnabbreviatedSig sig]
+        '": ",:formatUnabbreviatedSig sig]
   if exp then
     sayBrightly ['%l,:bright '"  Missing Exported Functions:"]
     for [op,sig] in exp for i in 1.. repeat
       sayBrightly ['"      [",i,'"]",:bright op,
-        ": ",:formatUnabbreviatedSig sig]
+        '": ",:formatUnabbreviatedSig sig]
 
 --% domain view code
 
@@ -704,7 +704,7 @@ compDefineCapsuleFunction(df is ['DEF, form, signature, body],
 
 getSignatureFromMode(form,e) ==
   getmode(opOf form,e) is ['Mapping,:signature] =>
-    #form~=#signature => stackAndThrow ["Wrong number of arguments: ",form]
+    #form~=#signature => stackAndThrow ['"Wrong number of arguments: ",form]
     EQSUBSTLIST(rest form,take(#rest form,$FormalMapVariableList),signature)
 
 hasSigInTargetCategory(argl,form,opsig,e) ==
@@ -724,7 +724,7 @@ hasSigInTargetCategory(argl,form,opsig,e) ==
   0=c => (#(sig:= getSignatureFromMode(form,e))=#form => sig; nil)
   1<c =>
     sig:= first potentialSigList
-    stackWarning ["signature of lhs not unique:",:bright sig,"chosen"]
+    stackWarning ['"signature of lhs not unique:",:bright sig,'"chosen"]
     sig
   nil --this branch will force all arguments to be declared
 
@@ -732,7 +732,7 @@ compareMode2Arg(x,m) == null x or modeEqual(x,m)
 
 getArgumentModeOrMoan(x,form,e) ==
   getArgumentMode(x,e) or
-    stackSemanticError(["argument ",x," of ",form," is not declared"],nil)
+    stackSemanticError(['"argument ",x,'" of ",form,'" is not declared"],nil)
 
 getArgumentMode(x,e) ==
   STRINGP x => x
@@ -745,7 +745,7 @@ checkAndDeclare(argl,form,sig,e) ==
   for a in argl for m in rest sig repeat
     m1:= getArgumentMode(a,e) =>
       not modeEqual(m1,m) =>
-        stack:= ["   ",:bright a,'"must have type ",m,
+        stack:= ['"   ",:bright a,'"must have type ",m,
           '" not ",m1,'%l,:stack]
     e:= put(a,'mode,m,e)
   if stack then
@@ -763,11 +763,11 @@ getSignature(op, argModeList, e) ==
   null sigl =>
     (u := getmode(op, e)) is ['Mapping, :sig] => sig
     SAY '"************* USER ERROR **********"
-    SAY("available signatures for ",op,": ")
+    SAY('"available signatures for ",op,'": ")
     if null mmList
-       then SAY "    NONE"
-       else for [[dc,:sig],:.] in mmList repeat printSignature("     ",op,sig)
-    printSignature("NEED ",op,["?",:argModeList])
+       then SAY '"    NONE"
+       else for [[dc,:sig],:.] in mmList repeat printSignature('"     ",op,sig)
+    printSignature('"NEED ",op,['"?",:argModeList])
     nil
   for u in sigl repeat
     for v in sigl | not (u=v) repeat
@@ -777,7 +777,7 @@ getSignature(op, argModeList, e) ==
               --well as a total one.  SourceLevelSubsume (from CATEGORY BOOT)
               --should do this
   1=#sigl => first sigl
-  stackSemanticError(["duplicate signatures for ",op,": ",argModeList],nil)
+  stackSemanticError(['"duplicate signatures for ",op,'": ",argModeList],nil)
 
 
 putInLocalDomainReferences (def := [opName,[lam,varl,body]]) ==
@@ -854,7 +854,7 @@ compileConstructor1 (form:=[fn,[key,vl,:bodyl]]) ==
 
 constructMacro (form is [nam,[lam,vl,body]]) ==
   not (and/[atom x for x in vl]) =>
-    stackSemanticError(["illegal parameters for macro: ",vl],nil)
+    stackSemanticError(['"illegal parameters for macro: ",vl],nil)
   ["XLAM",vl':= [x for x in vl | IDENTP x],body]
 
 uncons x ==
@@ -921,8 +921,8 @@ compSubDomain1(domainForm,predicate,m,e) ==
     compMakeDeclaration([":","#1",domainForm],$EmptyMode,addDomain(domainForm,e))
   u:=
     compOrCroak(predicate,$Boolean,e) or
-      stackSemanticError(["predicate: ",predicate,
-        " cannot be interpreted with #1: ",domainForm],nil)
+      stackSemanticError(['"predicate: ",predicate,
+        '" cannot be interpreted with #1: ",domainForm],nil)
   prefixPredicate:= lispize u.expr
   $lisplibSuperDomain:=
     [domainForm,predicate]
@@ -970,17 +970,17 @@ doIt(item, $predl, e) ==
   isDomainForm(item, e) =>
      -- convert naked top level domains to import
     u:= ['import, [first item,:rest item]]
-    userError ["Use: import ", [first item,:rest item]]
+    userError ['"Use: import ", [first item,:rest item]]
     RPLACA(item,first u)
     RPLACD(item,rest u)
     doIt(item, $predl, e)
   item is [":=", lhs, rhs, :.] =>
     not (compOrCroak(item, $EmptyMode, e) is [code, ., e]) =>
-      stackSemanticError(["cannot compile assigned value to",:bright lhs],nil)
+      stackSemanticError(['"cannot compile assigned value to",:bright lhs],nil)
       e
     not (code is ['LET,lhs',rhs',:.] and atom lhs') =>
       code is ["PROGN",:.] =>
-         stackSemanticError(["multiple assignment ",item," not allowed"],nil)
+         stackSemanticError(['"multiple assignment ",item,'" not allowed"],nil)
          e
       RPLACA(item,first code)
       RPLACD(item,rest code)
@@ -1077,7 +1077,7 @@ doItWhere(item is [.,form,:exprList], $predl, eInit) ==
 
 compJoin(["Join",:argl],m,e) ==
   catList:= [(compForMode(x,$Category,e) or return 'failed).expr for x in argl]
-  catList='failed => stackSemanticError(["cannot form Join of: ",argl],nil)
+  catList='failed => stackSemanticError(['"cannot form Join of: ",argl],nil)
   catList':=
     [extract for x in catList] where
       extract() ==
@@ -1100,7 +1100,7 @@ compJoin(["Join",:argl],m,e) ==
             body
         x is ["mkCategory",:.] => x
         atom x and getmode(x,e)=$Category => x
-        stackSemanticError(["invalid argument to Join: ",x],nil)
+        stackSemanticError(['"invalid argument to Join: ",x],nil)
         x
   T:= [wrapDomainSub(parameters,["Join",:catList']),$Category,e]
   convert(T,m)

--- a/src/interp/format.boot
+++ b/src/interp/format.boot
@@ -219,7 +219,7 @@ formatOperationWithPred([[op,sig],pred,.]) ==
     concat(formatOpSignature(op, sig), formatIf pred)
 
 formatOpSignature(op,sig) ==
-  concat('%b,formatOpSymbol(op,sig),'%d,": ",formatSignature sig)
+  concat('%b,formatOpSymbol(op,sig),'%d,'": ",formatSignature sig)
 
 formatOpConstant op ==
   concat('%b,formatOpSymbol(op,'($)),'%d,'": constant")
@@ -268,21 +268,21 @@ formatSignatureArgs sml ==
   formatSignatureArgs0 sml
 
 formatSignature0 sig ==
-  null sig => "() -> ()"
+  null sig => '"() -> ()"
   INTEGERP sig => '"hashcode"
   [tm,:sml] := sig
   sourcePart:= formatSignatureArgs0 sml
   targetPart:= prefix2String0 tm
-  dollarPercentTran concat(sourcePart,concat(" -> ",targetPart))
+  dollarPercentTran concat(sourcePart,concat('" -> ",targetPart))
 
 formatSignatureArgs0(sml) ==
 -- formats the arguments of a signature
-  null sml => ["_(_)"]
+  null sml => ['"_(_)"]
   null rest sml => prefix2String0 first sml
   argList:= prefix2String0 first sml
   for m in rest sml repeat
-    argList:= concat(argList,concat(", ",prefix2String0 m))
-  concat("_(",concat(argList,"_)"))
+    argList:= concat(argList,concat('", ",prefix2String0 m))
+  concat('"_(",concat(argList,'"_)"))
 
 --% Conversions to string form
 
@@ -511,7 +511,7 @@ formJoin1(op,u) ==
     $abbreviateJoin = true => concat(formJoin2 argl,'%b,'"with",'%d,'"...")
     $permitWhere = true =>
       opList:= formatJoinKey(r,id)
-      $whereList:= concat($whereList,"%l",$declVar,": ",
+      $whereList:= concat($whereList,"%l",$declVar,'": ",
         formJoin2 argl,'%b,'"with",'%d,"%i",opList,"%u")
       formJoin2 argl
     opList:= formatJoinKey(r,id)
@@ -550,7 +550,7 @@ formJoin2String (u:=[:argl,last]) ==
   last is ["CATEGORY",.,:atsigList] =>
     postString:= concat("_(",formTuple2String atsigList,"_)")
     #argl=1 => concat(first argl,'" with ",postString)
-    concat(application2String('Join,argl, NIL)," with ",postString)
+    concat(application2String('Join,argl, NIL),'" with ",postString)
   application2String('Join,u, NIL)
 
 sub_to_string(u) ==
@@ -573,13 +573,13 @@ formCollect2String [:itl,body] ==
 formIterator2String x ==
   x is ["STEP",y,s,.,:l] =>
     tail:= (l is [f] => form2StringLocal f; nil)
-    concat("for ",y," in ",s,'"..",tail)
-  x is ["tails",y] => concat("tails ",formatIterator y)
-  x is ["reverse",y] => concat("reverse ",formatIterator y)
-  x is ["|",y,p] => concat(formatIterator y," | ",form2StringLocal p)
-  x is ["until",p] => concat("until ",form2StringLocal p)
-  x is ["while",p] => concat("while ",form2StringLocal p)
-  systemErrorHere "formatIterator"
+    concat('"for ",y,'" in ",s,'"..",tail)
+  x is ["tails",y] => concat('"tails ",formatIterator y)
+  x is ["reverse",y] => concat('"reverse ",formatIterator y)
+  x is ["|",y,p] => concat(formatIterator y,'" | ",form2StringLocal p)
+  x is ["until",p] => concat('"until ",form2StringLocal p)
+  x is ["while",p] => concat('"while ",form2StringLocal p)
+  systemErrorHere '"formatIterator"
 
 tuple2String argl ==
   fn1 argl where
@@ -662,9 +662,9 @@ app2StringWrap(string, linkInfo) == string
 record2String x ==
   argPart := NIL
   for [":",a,b] in x repeat argPart:=
-    concat(argPart,",",a,": ",form2StringLocal b)
+    concat(argPart,'",",a,'": ",form2StringLocal b)
   null argPart => '"Record()"
-  concat("Record_(",rest argPart,"_)")
+  concat('"Record_(",rest argPart,'"_)")
 
 plural(n,string) ==
   suffix:=

--- a/src/interp/g-cndata.boot
+++ b/src/interp/g-cndata.boot
@@ -177,7 +177,7 @@ unabbrevSpecialForms(op,arglist,modeIfTrue) ==
 unabbrevRecordComponent(a,modeIfTrue) ==
   a is ["Declare",b,T] or a is [":",b,T] =>
     [":",b,unabbrev1(T,modeIfTrue)]
-  userError "wrong format for Record type"
+  userError '"wrong format for Record type"
 
 unabbrevUnionComponent(a,modeIfTrue) ==
   a is ["Declare",b,T] or a is [":",b,T] =>

--- a/src/interp/g-error.boot
+++ b/src/interp/g-error.boot
@@ -189,7 +189,7 @@ coerce_failure_msg(val, submode, mode) ==
     check_union_failure_msg(val, submode, mode)
 
 IdentityError(op) ==
-    error(["No identity element for reduce of empty list using operation",op])
+    error(['"No identity element for reduce of empty list using operation",op])
 
 throwMessage(:msg) ==
   if $compilingMap then clearCache $mapName

--- a/src/interp/g-opt.boot
+++ b/src/interp/g-opt.boot
@@ -204,7 +204,7 @@ optSpecialCall(x,y,n) ==
 
 compileTimeBindingOf u ==
   NULL(name:= BPINAME u)  => keyedSystemError("S2OO0001",[u])
-  name="Undef" => MOAN "optimiser found unknown function"
+  name="Undef" => MOAN '"optimiser found unknown function"
   name
 
 optMkRecord ["mkRecord",:u] ==

--- a/src/interp/g-util.boot
+++ b/src/interp/g-util.boot
@@ -242,11 +242,11 @@ removeZeroOneDestructively t ==
 -- the key function extracts the key from an item for comparison by pred
 
 listSort(pred,list,:optional) ==
-   NOT functionp pred => error "listSort: first arg must be a function"
-   NOT LISTP list => error "listSort: second argument must be a list"
+   NOT functionp pred => error '"listSort: first arg must be a function"
+   NOT LISTP list => error '"listSort: second argument must be a list"
    NULL optional => mergeSort(pred,function Identity,list,LENGTH list)
    key := CAR optional
-   NOT functionp key => error "listSort: last arg must be a function"
+   NOT functionp key => error '"listSort: last arg must be a function"
    mergeSort(pred,key,list,LENGTH list)
 
 -- non-destructive merge sort using NOT GGREATERP as predicate
@@ -307,7 +307,7 @@ spadThrowBrightly x ==
 --% Type Formatting Without Abbreviation
 
 formatUnabbreviatedSig sig ==
-  null sig => ["() -> ()"]
+  null sig => ['"() -> ()"]
   [target,:args] := sig
   target := formatUnabbreviated target
   null args => ['"() -> ",:target]

--- a/src/interp/ht-root.boot
+++ b/src/interp/ht-root.boot
@@ -198,14 +198,14 @@ htGreekSearch(filter) ==
   htInitPage('"Greek Names",nil)
   null matches =>
     htInitPage(['"Greek names matching search string {\em ",ss,'"}"],nil)
-    htSay("\vspace{2}\centerline{Sorry, but no greek letters match your search string}\centerline{{\em ",ss,"}}\centerline{Click on the up-arrow to try again}")
+    htSay('"\vspace{2}\centerline{Sorry, but no greek letters match your search string}\centerline{{\em ",ss,'"}}\centerline{Click on the up-arrow to try again}")
     htShowPage()
   htInitPage(['"Greek letters matching search string {\em ",ss,'"}"],nil)
   if nonmatches
     then htSayList([
        '"The greek letters that {\em match} your search string {\em ",
        ss, '"}:"])
-    else htSay('"Your search string {\em ",ss,"} matches all of the greek letters:")
+    else htSay('"Your search string {\em ",ss,'"} matches all of the greek letters:")
   htSay('"{\em \table{")
   for x in matches repeat htSayList(['"{", x, '"}"])
   htSay('"}}\vspace{1}")
@@ -233,14 +233,14 @@ htTextSearch(filter) ==
   htInitPage('"Text Matches",nil)
   null matches =>
     htInitPage(['"Lines matching search string {\em ",s,'"}"],nil)
-    htSay("\vspace{2}\centerline{Sorry, but no lines match your search string}\centerline{{\em ",s,"}}\centerline{Click on the up-arrow to try again}")
+    htSay('"\vspace{2}\centerline{Sorry, but no lines match your search string}\centerline{{\em ",s,'"}}\centerline{Click on the up-arrow to try again}")
     htShowPage()
   htInitPage(['"Lines matching search string {\em ",s,'"}"],nil)
   if nonmatches
     then htSayList([
            '"The lines that {\em match} your search string {\em ",
            s, '"}:"])
-    else htSay('"Your search string {\em ",s,"} matches both lines:")
+    else htSay('"Your search string {\em ",s,'"} matches both lines:")
   htSay('"{\em \table{")
   for x in matches repeat htSayList(['"{", x, '"}"])
   htSay('"}}\vspace{1}")

--- a/src/interp/htsetvar.boot
+++ b/src/interp/htsetvar.boot
@@ -126,7 +126,7 @@ htSetLiterals(htPage,name,message,variable,values,functionToCall) ==
   bcHt '"Select one of the following: \newline\tab{3} "
   links := [[STRCONC('"",STRINGIMAGE opt), '"\newline\tab{3}", functionToCall, opt] for opt in values]
   htMakePage [['bcLispLinks, :links]]
-  bcHt ["\indent{0}\newline\vspace{1} The current setting is: {\em ",
+  bcHt ['"\indent{0}\newline\vspace{1} The current setting is: {\em ",
         translateTrueFalse2YesNo EVAL variable, '"} "]
   htShowPage()
 
@@ -343,7 +343,7 @@ htMarkTree(tree,n) ==
     branch.3 = 'TREE => htMarkTree(branch.5,n + 1)
 
 htSetHistory htPage ==
-  msg := "when the history facility is on (yes), results of computations are saved in memory"
+  msg := '"when the history facility is on (yes), results of computations are saved in memory"
   data := ['history,msg,'history,'LITERALS,'$HiFiAccess,'(on off yes no)]
   htShowLiteralsPage(htPage,data)
 
@@ -434,7 +434,7 @@ htCacheSet htPage ==
   htInitPage('"Cache Summary",nil)
   bcHt '"In general, interpreter functions "
   bcHt
-    $cacheCount = 0 => "will {\em not} be cached."
+    $cacheCount = 0 => '"will {\em not} be cached."
     bcHt '"cache "
     htAllOrNum $cacheCount
     '"} values."

--- a/src/interp/i-intern.boot
+++ b/src/interp/i-intern.boot
@@ -671,7 +671,7 @@ put(x,prop,val,e) ==
   null atom x => put(first x,prop,val,e)
   newProplist:= augProplistOf(x,prop,val,e)
   prop="modemap" and $insideCapsuleFunctionIfTrue=true =>
-    SAY ["**** modemap PUT on CapsuleModemapFrame: ",val]
+    SAY ['"**** modemap PUT on CapsuleModemapFrame: ",val]
     $CapsuleModemapFrame:=
       addBinding(x,augProplistOf(x,"modemap",val,$CapsuleModemapFrame),
         $CapsuleModemapFrame)

--- a/src/interp/i-map.boot
+++ b/src/interp/i-map.boot
@@ -369,7 +369,7 @@ clearDep1(x,toDoList,doneList,depList) ==
 
 displayRule(op,rule) ==
   null rule => nil
-  mathprint ["CONCAT", "Definition:   ", outputMapTran(op, rule)]
+  mathprint ['"CONCAT", '"Definition:   ", outputMapTran(op, rule)]
   nil
 
 outputFormat(x,m) ==

--- a/src/interp/i-output.boot
+++ b/src/interp/i-output.boot
@@ -50,7 +50,7 @@ init_output_properties() ==
       ["+->", '" +-> "], ["SEGMENT", '".."], ["in", '" in "], _
       ["~=", '"~="], ["JOIN", '" JOIN "], ["EQUATNUM", '"  "], _
       ["=", '" = "], ["==", '" == "], [">=", '" >= "], [">", '" > "], _
-      ["<=", '" <= "], ["<", '" < "], ["|", '" | "], ["+", " + "], _
+      ["<=", '" <= "], ["<", '" < "], ["|", '" | "], ["+", '" + "], _
       ["-", '" - "], ["WHERE", '" WHERE "], ["MAX", '" MAX "], _
       ["MIN", '" MIN "]] repeat
         MAKEPROP(first(sv), 'INFIXOP, first(rest(sv)))
@@ -823,7 +823,7 @@ WIDTH u ==
         l + negative
     k := INTEGER_-LENGTH(u)
     k > MOST_-POSITIVE_-DOUBLE_-FLOAT =>
-        SAY("Number too big")
+        SAY('"Number too big")
         THROW('outputFailure,'outputFailure)
 
     if (k < 61) then

--- a/src/interp/i-spec1.boot
+++ b/src/interp/i-spec1.boot
@@ -360,7 +360,7 @@ upcase t ==
   if first unionDoms is ['_:,.,.] then
      for i in 0.. for d in unionDoms repeat
         if d is ['_:,=rhs,.] then rhstag := i
-     if NULL rhstag then error "upcase: bad Union form"
+     if NULL rhstag then error '"upcase: bad Union form"
      $genValue =>
         rhstag = first unwrap objVal triple => code := wrap(true)
         code := wrap(false)
@@ -539,7 +539,7 @@ upLoopIters itrl ==
       -- following is an optimization
       typeIsASmallInteger(get(index,'mode,$env)) =>
         RPLACA(iter,'ISTEP)
-    throwKeyedMsg("Malformed iterator")
+    throwKeyedMsg('"Malformed iterator")
 
 upLoopIterIN(iter,index,s) ==
   iterMs := bottomUp s
@@ -893,9 +893,9 @@ checkForFreeVariables(v,locals) ==
               $boundVariables := cons(var, $boundVariables)
           var
         ["SETF",newvar,checkForFreeVariables(form,locals)]
-      error "Non-simple variable bindings are not currently supported"
+      error '"Non-simple variable bindings are not currently supported"
     op = "PROG" =>
-      error "Non-simple variable bindings are not currently supported"
+      error '"Non-simple variable bindings are not currently supported"
     op = "LAMBDA" => v
     op = "QUOTE" => v
     op = "getValueFromEnvironment" => v

--- a/src/interp/i-syscmd.boot
+++ b/src/interp/i-syscmd.boot
@@ -485,7 +485,7 @@ compileAsharpCmd1 args ==
         fullopt := selectOptionLC(optname,optList,nil)
 
         fullopt = 'new       => nil
-        fullopt = 'old  => error "Internal error: compileAsharpCmd got )old"
+        fullopt = 'old  => error '"Internal error: compileAsharpCmd got )old"
         fullopt = 'quiet     => beQuiet := true
         fullopt = 'noquiet   => beQuiet := false
 
@@ -776,7 +776,7 @@ displayMacros names ==
             first := NIL
         displayParserMacro macro
     macro in imacs => 'iterate
-    sayBrightly (["   ",'%b, macro, '%d, " is not a known FriCAS macro."])
+    sayBrightly (['"   ",'%b, macro, '%d, '" is not a known FriCAS macro."])
 
   -- now system ones
 
@@ -817,7 +817,7 @@ displayWorkspaceNames() ==
   sayMessage '"Names of User-Defined Objects in the Workspace:"
   names := MSORT append(getWorkspaceNames(),pmacs)
   if null names
-    then sayBrightly "   * None *"
+    then sayBrightly '"   * None *"
     else sayAsManyPerLineAsPossible [object2String x for x in names]
   imacs := SETDIFFERENCE(imacs,pmacs)
   if imacs then
@@ -941,23 +941,23 @@ displayModemap(v,val,giveVariableIfNil) ==
       [[local,:signature],fn,:.]:= mm
       local='interpOnly => nil
       varPart:= (giveVariableIfNil => nil; ['" of",:bright v])
-      prefix:= ["   Compiled function type",:varPart,": "]
+      prefix:= ['"   Compiled function type",:varPart,'": "]
       sayBrightly concat(prefix,formatSignature signature)
 
 displayMode(v,mode,giveVariableIfNil) ==
   null mode => nil
-  varPart:= (giveVariableIfNil => nil; [" of",:bright fixObjectForPrinting v])
-  sayBrightly concat("   Declared type or mode",
-    varPart,":   ",prefix2String mode)
+  varPart:= (giveVariableIfNil => nil; ['" of",:bright fixObjectForPrinting v])
+  sayBrightly concat('"   Declared type or mode",
+    varPart,'":   ",prefix2String mode)
 
 displayCondition(v,condition,giveVariableIfNil) ==
-  varPart:= (giveVariableIfNil => nil; [" of",:bright v])
+  varPart:= (giveVariableIfNil => nil; ['" of",:bright v])
   condPart:= condition or 'true
-  sayBrightly concat("   condition",varPart,":  ",pred2English condPart)
+  sayBrightly concat('"   condition",varPart,'":  ",pred2English condPart)
 
 getAndSay(v,prop) ==
-  val:= getI(v,prop) => sayMSG ["    ",val,'%l]
-  sayMSG ["    none",'%l]
+  val:= getI(v,prop) => sayMSG ['"    ",val,'%l]
+  sayMSG ['"    none",'%l]
 
 displayType(op, u, omitVariableNameIfTrue) ==
   null u =>
@@ -970,7 +970,7 @@ displayType(op, u, omitVariableNameIfTrue) ==
   NIL
 
 displayValue(op, u, omitVariableNameIfTrue) ==
-  null u => sayMSG ["   Value of ", fixObjectForPrinting PNAME op,
+  null u => sayMSG ['"   Value of ", fixObjectForPrinting PNAME op,
                     '":  (none)"]
   expr := objValUnwrap(u)
   expr is [op1, :.] and (op1 = 'SPADMAP) =>
@@ -1021,15 +1021,15 @@ helpSpad2Cmd args ==
   -- try to use new stuff first
   if newHelpSpad2Cmd(args) then return nil
 
-  sayBrightly "Available help topics for system commands are:"
-  sayBrightly ""
-  sayBrightly " boot   cd     clear    close     compile   display"
-  sayBrightly " edit   fin    frame    help      history   library"
-  sayBrightly " lisp   load   ltrace   pquit     quit      read"
-  sayBrightly " set    show   spool    synonym   system    trace"
-  sayBrightly " undo   what"
-  sayBrightly ""
-  sayBrightly "Issue _")help help_" for more information about the help command."
+  sayBrightly '"Available help topics for system commands are:"
+  sayBrightly '""
+  sayBrightly '" boot   cd     clear    close     compile   display"
+  sayBrightly '" edit   fin    frame    help      history   library"
+  sayBrightly '" lisp   load   ltrace   pquit     quit      read"
+  sayBrightly '" set    show   spool    synonym   system    trace"
+  sayBrightly '" undo   what"
+  sayBrightly '""
+  sayBrightly '"Issue _")help help_" for more information about the help command."
 
   nil
 
@@ -2101,16 +2101,16 @@ loadSpad2Cmd args ==
     NIL
 
 reportCount () ==
-  centerAndHighlight(" Current Count Settings ",$LINELENGTH,specialChar 'hbar)
-  SAY " "
-  sayBrightly [:bright " cache",fillerSpaces(30,'".")," ",$cacheCount]
+  centerAndHighlight('" Current Count Settings ",$LINELENGTH,specialChar 'hbar)
+  SAY '" "
+  sayBrightly [:bright '" cache",fillerSpaces(30,'"."),'" ",$cacheCount]
   if $cacheAlist then
     for [a,:b] in $cacheAlist repeat
       aPart:= linearFormatName a
       n:= sayBrightlyLength aPart
-      sayBrightly concat("     ",aPart," ",fillerSpaces(32-n,'".")," ",b)
-  SAY " "
-  sayBrightly [:bright " stream",fillerSpaces(29,'".")," ",$streamCount]
+      sayBrightly concat('"     ",aPart,'" ",fillerSpaces(32-n,'"."),'" ",b)
+  SAY '" "
+  sayBrightly [:bright '" stream",fillerSpaces(29,'"."),'" ",$streamCount]
 
 --% )nopiles
 
@@ -2119,12 +2119,12 @@ nopiles l == nopilesSpad2Cmd l
 nopilesSpad2Cmd l ==
     null l => setNopiles ("{")
     #l > 1 =>
-       SAY "nopiles takes a single argument"
+       SAY '"nopiles takes a single argument"
     #l = 0 => setNopiles ("{")
     l is [opt] =>
        opt = 'brace => setNopiles ("{")
        opt = 'parenthesis => setNopiles ("(")
-       SAY "nopiles only takes 'brace' or 'parenthesis' as an argument"
+       SAY '"nopiles only takes 'brace' or 'parenthesis' as an argument"
 
 
 --% )quit
@@ -2241,7 +2241,7 @@ reportOperations(oldArg,u) ==
   $resolve_level : local := 15
   null u => nil
   u = $quadSymbol =>
-     sayBrightly ['"   mode denotes", :bright '"any", "type"]
+     sayBrightly ['"   mode denotes", :bright '"any", '"type"]
   u = "%" =>
     sayKeyedMsg("S2IZ0063",NIL)
     sayKeyedMsg("S2IZ0064",NIL)
@@ -2519,7 +2519,7 @@ diffAlist(new,old) ==
 
 reportUndo acc ==
   for [name,:proplist] in acc repeat
-    sayBrightly STRCONC("Properties of ",PNAME name,'" ::")
+    sayBrightly STRCONC('"Properties of ",PNAME name,'" ::")
     curproplist := LASSOC(name,CAAR $InteractiveFrame)
     for [prop,:value] in proplist repeat
       sayBrightlyNT ['"  ",prop,'" was: "]
@@ -2718,7 +2718,7 @@ apropos l ==
 
 
 printSynonyms(patterns) ==
-  centerAndHighlight("System Command Synonyms",$LINELENGTH,specialChar 'hbar)
+  centerAndHighlight('"System Command Synonyms",$LINELENGTH,specialChar 'hbar)
   ls := filterListOfStringsWithFn(patterns, [[STRINGIMAGE a,:b]
     for [a,:b] in synonymsForUserLevel $CommandSynonymAlist],
       function first)
@@ -2745,7 +2745,7 @@ printLabelledList(ls,label1,label2,prefix,patterns) ==
   sayBrightly '""
 
 whatCommands(patterns) ==
-  label := STRCONC("System Commands for User Level: ",
+  label := STRCONC('"System Commands for User Level: ",
     STRINGIMAGE $UserLevel)
   centerAndHighlight(label,$LINELENGTH,specialChar 'hbar)
   l := filterListOfStrings(patterns,
@@ -2758,7 +2758,7 @@ whatCommands(patterns) ==
       '%l,'"   ",'%b,:blankList patterns,'%d]
   if l then
     sayAsManyPerLineAsPossible l
-    SAY " "
+    SAY '" "
   patterns => nil  -- don't be so verbose
   sayKeyedMsg("S2IZ0046",NIL)
   nil

--- a/src/interp/interop.boot
+++ b/src/interp/interop.boot
@@ -56,7 +56,7 @@ DNameTupleID  := 2
 DNameOtherID  := 3
 
 DNameToSExpr1 dname ==
-  NULL dname => error "unexpected domain name"
+  NULL dname => error '"unexpected domain name"
   first dname = DNameStringID =>
     INTERN(CompStrToString rest dname)
   name0 := DNameToSExpr1 first rest dname
@@ -355,7 +355,7 @@ basicLookup(op,sig,domain,dollar) ==
      VECP dollar => hashType(dollar.0,0)
      hashType(dollar,0)
   box := [nil]
-  not VECP(dispatch := first domain) => error "bad domain format"
+  not VECP(dispatch := first domain) => error '"bad domain format"
   lookupFun := dispatch.3
   dispatch.0 = 0 =>  -- new compiler domain object
        hashSig :=
@@ -393,7 +393,7 @@ basicLookup(op,sig,domain,dollar) ==
 
 basicLookupCheckDefaults(op,sig,domain,dollar) ==
   box := [nil]
-  not VECP(dispatch := first dollar) => error "bad domain format"
+  not VECP(dispatch := first dollar) => error '"bad domain format"
   lookupFun := dispatch.3
   dispatch.0 = 0  =>  -- new compiler domain object
        hashPercent :=
@@ -510,7 +510,7 @@ hashNewLookupInTable(op,sig,dollar,[domain,opvec],flag) ==
   success := false
   if $monitorNewWorld then
     sayLooking(concat('"---->",form2String devaluate domain,
-      '"----> searching op table for:","%l","  "),op,sig,dollar)
+      '"----> searching op table for:","%l",'"  "),op,sig,dollar)
   someMatch := false
   numvec := getDomainByteVector domain
   predvec := domain.3

--- a/src/interp/iterator.boot
+++ b/src/interp/iterator.boot
@@ -40,7 +40,7 @@ compReduce1(form is ["REDUCE",op,.,collectForm],m,e,$formalArgList) ==
   [collectOp,:itl,body]:= collectForm
   if STRINGP op then op:= INTERN op
   not MEMQ(collectOp,'(COLLECT COLLECTV COLLECTVEC)) =>
-        systemError ["illegal reduction form:",form]
+        systemError ['"illegal reduction form:",form]
   $sideEffectsList: local := nil
   $until: local := nil
   $initList: local := nil
@@ -173,7 +173,7 @@ compIterator1(it, e) ==
         [res, e]
     [mOver, mUnder] :=
       modeIsAggregateOf("List",m,e) or return
-         stackMessage ["mode: ",m," must be a list of some mode"]
+         stackMessage ['"mode: ",m,'" must be a list of some mode"]
     if null get(x,"mode",e) then [.,.,e]:=
       compMakeDeclaration([":",x,mUnder],$EmptyMode,e) or return nil
     e:= put(x,"value",[genSomeVariable(),mUnder,e],e)
@@ -184,7 +184,7 @@ compIterator1(it, e) ==
     [y',m,e]:= comp(y,$EmptyMode,e) or return nil
     [mOver,mUnder]:=
       modeIsAggregateOf("List",m,e) or return
-        stackMessage ["mode: ",m," must be a list of other modes"]
+        stackMessage ['"mode: ",m,'" must be a list of other modes"]
     if null get(x,"mode",e) then [.,.,e]:=
       compMakeDeclaration([":",x,m],$EmptyMode,e) or return nil
     e:= put(x,"value",[genSomeVariable(),m,e],e)
@@ -211,14 +211,14 @@ compIterator1(it, e) ==
             [["ISTEP",index,start'.expr,inc'.expr,:optFinal],e]
     [start,.,e]:=
       comp(start,$Integer,e) or return
-        stackMessage ["start value of index: ",start," must be an integer"]
+        stackMessage ['"start value of index: ",start,'" must be an integer"]
     [inc,.,e]:=
       comp(inc,$Integer,e) or return
-        stackMessage ["index increment:",inc," must be an integer"]
+        stackMessage ['"index increment:",inc,'" must be an integer"]
     if optFinal is [final] then
       [final,.,e]:=
         comp(final,$Integer,e) or return
-          stackMessage ["final value of index: ",final," must be an integer"]
+          stackMessage ['"final value of index: ",final,'" must be an integer"]
       optFinal:= [final]
     indexmode:=
       comp(CADDR it,$NonNegativeInteger,e) => $NonNegativeInteger
@@ -230,13 +230,13 @@ compIterator1(it, e) ==
   it is ["WHILE",p] =>
     [p',m,e]:=
       comp(p,$Boolean,e) or return
-        stackMessage ["WHILE operand: ",p," is not Boolean valued"]
+        stackMessage ['"WHILE operand: ",p,'" is not Boolean valued"]
     [["WHILE",p'],e]
   it is ["UNTIL",p] => ($until:= p; ['$until,e])
   it is ["|",x] =>
     u:=
       comp(x,$Boolean,e) or return
-        stackMessage ["SUCHTHAT operand: ",x," is not Boolean value"]
+        stackMessage ['"SUCHTHAT operand: ",x,'" is not Boolean value"]
     [["|",u.expr],u.env]
   nil
 
@@ -249,8 +249,8 @@ compIterator(it, e) ==
     it is ["INBY", i, n, inc] =>
         u := match_segment(i, n)
         u isnt ['STEP, i, a, 1, :r] =>
-            stackAndThrow ["   You cannot use", "%b", "by", "%d",
-                      "except for an explicitly indexed sequence."]
+            stackAndThrow ['"   You cannot use", "%b", '"by", "%d",
+                      '"except for an explicitly indexed sequence."]
         compIterator1(['STEP, i, a, inc, :r], e)
     it is ["IN", i, n] =>
         compIterator1(match_segment(i, n), e)

--- a/src/interp/lisplib.boot
+++ b/src/interp/lisplib.boot
@@ -344,7 +344,7 @@ augModemapsFromDomain1(name,functorForm,e) ==
     ["Mapping", categoryForm, :.] := mappingForm
     catform:= substituteCategoryArguments(rest functorForm,categoryForm)
     augModemapsFromCategory(name, functorForm, catform, e)
-  stackMessage [functorForm," is an unknown mode"]
+  stackMessage [functorForm,'" is an unknown mode"]
   e
 
 getSlot1FromCategoryForm ([op, :argl]) ==

--- a/src/interp/match.boot
+++ b/src/interp/match.boot
@@ -68,7 +68,7 @@ rightCharPosition(c,t,startpos) == --startpos often equals MAXINDEX t (rightmost
 
 stringPosition(s,t,startpos) ==
   n := SIZE t
-  if startpos < 0 or startpos > n then error "index out of range"
+  if startpos < 0 or startpos > n then error '"index out of range"
   if SIZE s = 0 then return startpos -- bug in STRPOS
   r := STRPOS(s,t,startpos,NIL)
   if EQ(r,NIL) then n else r

--- a/src/interp/modemap.boot
+++ b/src/interp/modemap.boot
@@ -178,7 +178,7 @@ substituteCategoryArguments(argl,catform) ==
 
 augModemapsFromCategory(domainName, functorForm, categoryForm, e) ==
   [fnAlist,e]:= evalAndSub(domainName, functorForm, categoryForm, e)
-  compilerMessage ["Adding ",domainName," modemaps"]
+  compilerMessage ['"Adding ",domainName,'" modemaps"]
   e:= putDomainsInScope(domainName,e)
   for [[op,sig,:.],cond,fnsel] in fnAlist repeat
       e:= addModemapKnown(op,domainName,sig,cond,fnsel,e)
@@ -202,7 +202,7 @@ getOperationAlist(name,functorForm,form) ==
     ($domainShell => $domainShell.(1); systemError '"$ has no shell now")
   T := compMakeCategoryObject(form, $tmp_e) =>
       ([., ., $tmp_e] := T; T.expr.(1))
-  stackMessage ["not a category form: ",form]
+  stackMessage ['"not a category form: ",form]
 
 substNames(domainName, functorForm, opalist) ==
   functorForm := SUBSTQ("$$","$", functorForm)
@@ -261,7 +261,7 @@ getDomainsInScope e ==
 
 putDomainsInScope(x,e) ==
   l:= getDomainsInScope e
-  if member(x,l) then SAY("****** Domain: ",x," already in scope")
+  if member(x,l) then SAY('"****** Domain: ",x,'" already in scope")
   newValue:= [x,:delete(x,l)]
   $insideCapsuleFunctionIfTrue => ($CapsuleDomainsInScope:= newValue; e)
   put("$DomainsInScope","special",newValue,e)

--- a/src/interp/msgdb.boot
+++ b/src/interp/msgdb.boot
@@ -548,7 +548,7 @@ spadStartUpMsgs() ==
   --  if not $displaySetValue then sayKeyedMsg("S2GL0007",NIL)
 --  if not $HiFiAccess then sayKeyedMsg("S2GL0008",NIL)
 --  version()
-  sayMSG " "
+  sayMSG '" "
 
 HELP() == sayKeyedMsg("S2GL0019",NIL)
 

--- a/src/interp/ncomp.boot
+++ b/src/interp/ncomp.boot
@@ -25,7 +25,7 @@ expandMacros(tree) ==
         mdef =>
             repval := first(mdef)
             null(rest(mdef)) => expandMacros(repval)
-            userError("macro call needs arguments")
+            userError('"macro call needs arguments")
         tree
     -- floating point numbers
     [op, :args] := tree
@@ -42,7 +42,7 @@ expandMacros(tree) ==
                 args
             #args = #margs =>
                 expandMacros(SUBLISLIS(args, margs, repval))
-            userError("invalid macro call, #args ~= #margs")
+            userError('"invalid macro call, #args ~= #margs")
         [op, :[expandMacros(x) for x in args]]
     [expandMacros(x) for x in tree]
 
@@ -91,7 +91,7 @@ define_macro(name, def) ==
         def := [def, :args]
     else
         SAY([name, def])
-        userError("Invalid macro definition")
+        userError('"Invalid macro definition")
     prev_def := HGET($MacroTable, name)
     PUSH([name, :prev_def], $restore_list)
     HPUT($MacroTable, name, def)
@@ -149,7 +149,7 @@ walkForm(tree) ==
     tree is ["==", head, def] => expandMacros(tree)
     tree is ["where", ["==", name, def], env] =>
         walkWhereList(name, def, env)
-    userError("Parsing error: illegal toplevel form")
+    userError('"Parsing error: illegal toplevel form")
     nil
 
 --------------------------------------------------------------------
@@ -198,7 +198,7 @@ processGlobals () ==
         if nt then
             handleKind(["DEF", form, [nt, :rest sig], body])
         else
-            SAY(["unhandled target", form])
+            SAY(['"unhandled target", form])
     boo_comp_cats()
 
 
@@ -288,7 +288,7 @@ computeTargetMode(lhs, rhs) ==
             pairlis:= [[v,:a] for a in argl for v in $FormalMapVariableList]
             -- substitute
             SUBLIS(pairlis, sig)
-        PRETTYPRINT("strange untyped def")
+        PRETTYPRINT('"strange untyped def")
         PRETTYPRINT([lhs, rhs, modemap])
         nil
     BREAK()
@@ -365,7 +365,7 @@ S_process(x) ==
     $TranslateOnly => $Translation := x
     $postStack =>
         displayPreCompilationErrors()
-        userError "precompilation failed"
+        userError '"precompilation failed"
     $PrintOnly =>
         FORMAT(true, '"~S   =====>~%", $currentLine)
         PRETTYPRINT(x)

--- a/src/interp/nruncomp.boot
+++ b/src/interp/nruncomp.boot
@@ -166,7 +166,7 @@ optDeltaEntry(op, sig, dc, eltOrConst, e) ==
           if not STRINGP var and (n := countXLAM(var, rhs)) ~= 1 then
               -- in current code base there are no cases like "f(x, y) == x"
               -- so throw an error if such case emerges.
-              stackAndThrow [op, " can not be properly inline optimized"]
+              stackAndThrow [op, '" can not be properly inline optimized"]
               return nil
   spadreplace
 
@@ -444,7 +444,7 @@ simplify_self_preds1(catvecListMaker, condCats) ==
     sub_data1 := [false, good_preds]
     condCats := boolean_subst(condCats, catvecListMaker, sub_data1)
     if not(first(sub_data1)) then
-        userError(["simplify_self_preds1: cannot simplify", $op, self_preds])
+        userError(['"simplify_self_preds1: cannot simplify", $op, self_preds])
     [condCats, first(sub_data1)]
 
 simplify_self_preds(catvecListMaker, condCats) ==
@@ -705,7 +705,7 @@ NRTsubstDelta(initSig) ==
           t = 5 => $NRTaddForm
           u:= $NRTdeltaList.($NRTdeltaLength+5-t)
           first u = 'domain => CADR u
-          error "bad $NRTdeltaList entry"
+          error '"bad $NRTdeltaList entry"
         MEMQ(first t, '(Mapping Union Record _:)) =>
            [first t, :[replaceSlotTypes(x) for x in rest t]]
         t

--- a/src/interp/nrunfast.boot
+++ b/src/interp/nrunfast.boot
@@ -266,7 +266,7 @@ lazyMatch(source,lazyt,dollar,domain) ==
       MEMQ(op,'(Union Mapping QUOTE)) =>
          and/[lazyMatchArg(s,a,dollar,domain) for s in sargl for a in argl]
       coSig := GETDATABASE(op,'COSIG)
-      NULL coSig => error ["bad Constructor op", op]
+      NULL coSig => error ['"bad Constructor op", op]
       and/[lazyMatchArg2(s,a,dollar,domain,flag)
            for s in sargl for a in argl for flag in rest coSig]
   STRINGP source and lazyt is ['QUOTE,=source] => true
@@ -344,7 +344,7 @@ newExpandLocalTypeForm([functorName,:argl],dollar,domain) ==
           [functorName,:[newExpandLocalTypeArgs(a,dollar,domain,true) for a in argl]]
   functorName = 'QUOTE => [functorName,:argl]
   coSig := GETDATABASE(functorName,'COSIG)
-  NULL coSig => error ["bad functorName", functorName]
+  NULL coSig => error ['"bad functorName", functorName]
   [functorName,:[newExpandLocalTypeArgs(a,dollar,domain,flag)
         for a in argl for flag in rest coSig]]
 

--- a/src/interp/nrunopt.boot
+++ b/src/interp/nrunopt.boot
@@ -119,7 +119,7 @@ makeCompactSigCode(sig) == [fn for x in sig] where
   fn ==
     x = '_$_$ => 2
     x = '$ => 0
-    NULL INTEGERP x => systemError ['"code vector slot is ",x,"; must be number"]
+    NULL INTEGERP x => systemError ['"code vector slot is ",x,'"; must be number"]
     x
 
 --=======================================================================
@@ -590,7 +590,7 @@ dcSizeAll() ==
     sayBrightly [s,'" : ",x]
     total := total + s
   sayBrightly '"------------total-------------"
-  sayBrightly [count," constructors; ",total," BYTES"]
+  sayBrightly [count,'" constructors; ",total,'" BYTES"]
 
 sum(:l) == +/l
 
@@ -675,7 +675,7 @@ NRTgetLookupFunction(domform,exCategory,addForm) ==
   if null extends then
     [u,msg,:v] := $why
     sayBrightly '"--------------non extending category----------------------"
-    sayBrightlyNT ['"..",:bright form2String domform,"of cat "]
+    sayBrightlyNT ['"..",:bright form2String domform,'"of cat "]
     PRINT u
     sayBrightlyNT bright msg
     if v then PRINT first v else TERPRI()

--- a/src/interp/package.boot
+++ b/src/interp/package.boot
@@ -38,7 +38,7 @@ mkList u ==
 mkOperatorEntry(opSig is [op,sig,:flag],pred,count) ==
   null flag => [opSig,pred,["ELT","$",count]]
   first flag="constant" => [[op,sig],pred,["CONST","$",count]]
-  systemError ["unknown variable mode: ",flag]
+  systemError ['"unknown variable mode: ",flag]
 
 --% Code for encoding function names inside package or domain
 

--- a/src/interp/parse.boot
+++ b/src/interp/parse.boot
@@ -108,7 +108,7 @@ parseTran x ==
   [op, :argl] := x
   u := (op is ['Sel, ., x] => x; op)
   SYMBOLP(u) and (fn := GET(u, 'parseTran)) =>
-      if op ~= u then SAY(["parseTran op ~= u", op, u])
+      if op ~= u then SAY(['"parseTran op ~= u", op, u])
       FUNCALL(fn, argl)
   [parseTran op, :parseTranList argl]
 

--- a/src/interp/setvars.boot
+++ b/src/interp/setvars.boot
@@ -223,9 +223,9 @@ displaySetVariableSettings(setTree,label) ==
   centerAndHighlight(STRCONC('"Current Values of ",label,
     '" Variables"),$LINELENGTH," ")
   TERPRI()
-  sayBrightly ["Variable     ",
-               "Description                                ",
-                 "Current Value"]
+  sayBrightly ['"Variable     ",
+               '"Description                                ",
+                 '"Current Value"]
   SAY fillerSpaces($LINELENGTH,specialChar 'hbar)
   subtree := nil
   for setData in setTree repeat
@@ -332,7 +332,7 @@ setExpose arg ==
 
 setExposeAdd arg ==
   (null arg) =>
-    centerAndHighlight ("The add Option",$LINELENGTH,specialChar 'hbar)
+    centerAndHighlight ('"The add Option",$LINELENGTH,specialChar 'hbar)
     --  give msg about exposure groups
     displayExposedGroups()
     --  give msg about explicitly exposed constructors
@@ -349,7 +349,7 @@ setExposeAdd arg ==
 
 setExposeAddGroup arg ==
   (null arg) =>
-    centerAndHighlight("The group Option",$LINELENGTH,specialChar 'hbar)
+    centerAndHighlight('"The group Option",$LINELENGTH,specialChar 'hbar)
     --  give msg about exposure groups
     displayExposedGroups()
     sayMSG '" "
@@ -379,7 +379,7 @@ setExposeAddGroup arg ==
 
 setExposeAddConstr arg ==
   (null arg) =>
-    centerAndHighlight ("The constructor Option",$LINELENGTH,
+    centerAndHighlight ('"The constructor Option",$LINELENGTH,
       specialChar 'hbar)
     --  give msg about explicitly exposed constructors
     displayExposedConstructors()
@@ -400,7 +400,7 @@ setExposeAddConstr arg ==
 
 setExposeDrop arg ==
   (null arg) =>
-    centerAndHighlight ("The drop Option",$LINELENGTH,specialChar 'hbar)
+    centerAndHighlight ('"The drop Option",$LINELENGTH,specialChar 'hbar)
     --  give msg about explicitly hidden constructors
     displayHiddenConstructors()
     sayMSG '" "
@@ -414,7 +414,7 @@ setExposeDrop arg ==
 
 setExposeDropGroup arg ==
   (null arg) =>
-    centerAndHighlight ("The group Option",$LINELENGTH,specialChar 'hbar)
+    centerAndHighlight ('"The group Option",$LINELENGTH,specialChar 'hbar)
     sayKeyedMsg("S2IZ0049L",NIL)
     sayMSG '" "
     displayExposedGroups()
@@ -440,7 +440,7 @@ setExposeDropGroup arg ==
 
 setExposeDropConstr arg ==
   (null arg) =>
-    centerAndHighlight ("The constructor Option",$LINELENGTH,
+    centerAndHighlight ('"The constructor Option",$LINELENGTH,
       specialChar 'hbar)
     sayKeyedMsg("S2IZ0049N",NIL)
     sayMSG '" "
@@ -515,18 +515,18 @@ sayAllCacheCounts () ==
 
 sayCacheCount(fn,n) ==
   prefix:=
-    fn => ["function",:bright linearFormatName fn]
-    n = 0 => ["interpreter functions "]
-    ["In general, interpreter functions "]
+    fn => ['"function",:bright linearFormatName fn]
+    n = 0 => ['"interpreter functions "]
+    ['"In general, interpreter functions "]
   n = 0 =>
     fn =>
       sayBrightly ['"   Caching for ",:prefix,
         '"is turned off"]
     sayBrightly '" In general, functions will cache no returned values."
   phrase:=
-    n="all" => [:bright "all","values."]
-    n=1 => [" only the last value."]
-    [" the last",:bright n,"values."]
+    n="all" => [:bright '"all",'"values."]
+    n=1 => ['" only the last value."]
+    ['" the last",:bright n,'"values."]
   sayBrightly ['"   ",:prefix,'"will cache",:phrase]
 
 setHistory arg ==

--- a/src/interp/sfsfun.boot
+++ b/src/interp/sfsfun.boot
@@ -898,7 +898,7 @@ c_to_r(c) ==
     if ZEROP(i) or (ABS(i) <  1.0E-10*(ABS r)) then
         r
     else
-        error "Result is not real."
+        error '"Result is not real."
 
 c_to_rf(c) == COERCE(c_to_r(c), 'DOUBLE_-FLOAT)
 

--- a/src/interp/showimp.boot
+++ b/src/interp/showimp.boot
@@ -71,20 +71,20 @@ showImp(dom,:options) ==
     [., ., :key] := first u
     sayBrightly
       key = 'constant =>
-        ["Constants implemented by",:bright form2String key,'":"]
-      ["Functions implemented by",:bright form2String key,'":"]
+        ['"Constants implemented by",:bright form2String key,'":"]
+      ['"Functions implemented by",:bright form2String key,'":"]
     u := showDomainsOp1(u,key)
   u := SORTBY('CDDR,defexports)
   while u repeat
     [., ., :key] := first u
     defop := INTERN(SUBSTRING((s := PNAME first key), 0, MAXINDEX s))
     domainForm := [defop,:CDDR key]
-    sayBrightly ["Default functions from",:bright form2String domainForm,'":"]
+    sayBrightly ['"Default functions from",:bright form2String domainForm,'":"]
     u := showDomainsOp1(u,key)
   u := SORTBY('CDDR,unexports)
   while u repeat
     [., ., :key] := first u
-    sayBrightly ["Not exported: "]
+    sayBrightly ['"Not exported: "]
     u := showDomainsOp1(u,key)
 
 --=======================================================================

--- a/src/interp/trace.boot
+++ b/src/interp/trace.boot
@@ -496,7 +496,7 @@ getTraceOption (x is [key,:l]) ==
 
 traceOptionError(opt,keys) ==
   null keys => stackTraceOptionError ["S2IT0007",[opt]]
-  commandAmbiguityError("trace option",opt,keys)
+  commandAmbiguityError('"trace option",opt,keys)
 
 resetTimers () ==
   for timer in $timer_list repeat
@@ -509,14 +509,14 @@ resetCounters () ==
 ptimers() ==
   null $timer_list => sayBrightly '"   no functions are timed"
   for timer in $timer_list repeat
-    sayBrightly ["  ",:bright timer,'_:,'" ",
+    sayBrightly ['"  ",:bright timer,'_:,'" ",
       EVAL(INTERN STRCONC(timer, '"_,TIMER")) /
         FLOAT($timerTicksPerSecond, 0.0), '" sec."]
 
 pcounters() ==
   null $count_list => sayBrightly '"   no functions are being counted"
   for k in $count_list repeat
-    sayBrightly ["  ",:bright k,'_:,'" ",
+    sayBrightly ['"  ",:bright k,'_:,'" ",
       EVAL INTERN STRCONC(k,'"_,COUNT"),'" times"]
 
 transOnlyOption l ==
@@ -712,9 +712,9 @@ spadTrace(domain,options) ==
               atom domain.n => nil
               functionSlot:= first domain.n
               GENSYMP functionSlot =>
-                (reportSpadTrace("Already Traced",x); nil)
+                (reportSpadTrace('"Already Traced",x); nil)
               null (BPINAME functionSlot) =>
-                (reportSpadTrace("No function for",x); nil)
+                (reportSpadTrace('"No function for",x); nil)
               true
   if listOfVariables then
     for [.,.,n] in sigSlotNumberAlist repeat
@@ -742,7 +742,7 @@ spadTrace(domain,options) ==
   if $reportSpadTrace then
     if $traceNoisely then printDashedLine()
     for x in orderBySlotNumber sigSlotNumberAlist repeat
-      reportSpadTrace("TRACING",x)
+      reportSpadTrace('"TRACING",x)
   currentEntry =>
     rplac(rest currentEntry,[:sigSlotNumberAlist,:currentAlist])
   $trace_names := [[domain, :sigSlotNumberAlist], :$trace_names]
@@ -825,7 +825,7 @@ letPrint(x,val,currentFunction) ==
     ((y:= LASSOC(currentFunction,$letAssoc)) or (y:= LASSOC("all",$letAssoc))) then
       if (y="all" or MEMQ(x,y)) and
         not (IS_GENVAR(x) or isSharpVarWithNum(x) or GENSYMP x) then
-         sayBrightlyNT [:bright x,": "]
+         sayBrightlyNT [:bright x,'": "]
          PRIN0 shortenForPrinting val
          TERPRI()
       if (y:= hasPair("BREAK",y)) and
@@ -849,7 +849,7 @@ letPrint2(x,printform,currentFunction) ==
       if (y:= hasPair("BREAK",y)) and
         (y="all" or MEMQ(x,y) and
           (not MEMQ((PNAME x).(0),'($ _#)) and not GENSYMP x)) then
-            break [:bright currentFunction,'"breaks after",:bright x,":= ",
+            break [:bright currentFunction,'"breaks after",:bright x,'":= ",
               printform]
   x
 
@@ -901,11 +901,11 @@ getOption(opt,l) ==
 
 reportSpadTrace(header,[op,sig,n,:t]) ==
   null $traceNoisely => nil
-  msg:= [header,'%b,op,":",'%d,rest sig," -> ",first sig," in slot ",n]
+  msg:= [header,'%b,op,'":",'%d,rest sig,'" -> ",first sig,'" in slot ",n]
   namePart:= nil --(t is (.,.,name,:.) => (" named ",name); NIL)
   tracePart:=
     t is [y,:.] and not null y =>
-      (y="all" => ['%b,"all",'%d,"vars"]; [" vars: ",y])
+      (y="all" => ['%b,'"all",'%d,'"vars"]; ['" vars: ",y])
     NIL
   sayBrightly [:msg,:namePart,:tracePart]
 
@@ -962,26 +962,26 @@ traceReply() ==
     for x in functionList | not isSubForRedundantMapName x]
   if functionList then
     2 = #functionList =>
-      sayMSG ["   Function traced: ",:functionList]
+      sayMSG ['"   Function traced: ",:functionList]
     (22 + sayBrightlyLength functionList) <= $LINELENGTH =>
-      sayMSG ["   Functions traced: ",:functionList]
-    sayBrightly "   Functions traced:"
+      sayMSG ['"   Functions traced: ",:functionList]
+    sayBrightly '"   Functions traced:"
     sayBrightly flowSegmentedMsg(functionList,$LINELENGTH,6)
   if $domains then
     displayList:= concat(prefix2String first $domains,
-          [:concat('",",'" ",prefix2String x) for x in rest $domains])
+          [:concat('", ",prefix2String x) for x in rest $domains])
     if atom displayList then displayList:= [displayList]
     sayBrightly '"   Domains traced: "
     sayBrightly flowSegmentedMsg(displayList,$LINELENGTH,6)
   if $packages then
     displayList:= concat(prefix2String first $packages,
-          [:concat(", ",prefix2String x) for x in rest $packages])
+          [:concat('", ",prefix2String x) for x in rest $packages])
     if atom displayList then displayList:= [displayList]
     sayBrightly '"   Packages traced: "
     sayBrightly flowSegmentedMsg(displayList,$LINELENGTH,6)
   if $constructors then
     displayList:= concat(abbreviate first $constructors,
-          [:concat(", ",abbreviate x) for x in rest $constructors])
+          [:concat('", ",abbreviate x) for x in rest $constructors])
     if atom displayList then displayList:= [displayList]
     sayBrightly '"   Parameterized constructors traced:"
     sayBrightly flowSegmentedMsg(displayList,$LINELENGTH,6)
@@ -1002,7 +1002,7 @@ _?t() ==
       isDomain d => '"domain"
       '"package"
     sayBrightly ['"   Functions traced in ",suffix,'%b,devaluate d,'%d,":"]
-    for x in orderBySlotNumber l repeat reportSpadTrace("   ",take(4,x))
+    for x in orderBySlotNumber l repeat reportSpadTrace('"   ",take(4,x))
     TERPRI()
 
 tracelet(fn, bin_def, vars) ==
@@ -1056,7 +1056,7 @@ break msg ==
     INTERRUPT()
 
 compileBoot fn ==
-  SAY("need to recompile: ", fn)
+  SAY('"need to recompile: ", fn)
 
 -- Monitor printouts
 
@@ -1111,7 +1111,7 @@ monitor_print_value(val, name) ==
             PRINC('"//", $trace_stream)
             PRIN1(val, $trace_stream)
             TERPRI($trace_stream)
-        PRINC("! ", $trace_stream)
+        PRINC('"! ", $trace_stream)
         PRIN1(EVAL(SUBST(MKQ(val), "*", first(u))), $trace_stream)
         TERPRI($trace_stream)
     PRINC('": ", $trace_stream)
@@ -1128,7 +1128,7 @@ monitor_get_value(n, fg) ==
         spadThrowBrightly('"cannot ask for value before execution")
     n = 9 => MKQ($monitor_caller)
     n <= SIZE($monitor_args) => MKQ(ELT($monitor_args, n - 1))
-    spadThrowBrightly(["FUNCTION", "%b", $monitor_name, "%d",
+    spadThrowBrightly(['"FUNCTION", "%b", $monitor_name, "%d",
                           '"does not have", "%b", n, "%d", '"arguments"])
 
 monitor_print_args(L, code, trans) ==
@@ -1216,9 +1216,9 @@ monitor_x1(TRACECODE, name, name1, V, TIMERNAM, EVAL_TIME) ==
     PRIN0($monitor_fun_depth, $trace_stream)
     sayBrightlyNT2(['">exit ", "%b", PNAME(name1), "%d"], $trace_stream)
     if TIMERNAM then
-        sayBrightlyNT2("(", $trace_stream) -- )
+        sayBrightlyNT2('"(", $trace_stream) -- )
         sayBrightlyNT2((EVAL_TIME/60.0), $trace_stream)
-        sayBrightlyNT2(" sec)", $trace_stream)
+        sayBrightlyNT2('" sec)", $trace_stream)
     if V = 1 then
         monitor_print_value(
               coerceTraceFunValue2E(name1, name, $monitor_value),


### PR DESCRIPTION
When I was exploring symbols in "BOOT" package, I found many strange symbols -- they are very long and contains space.  Turns out they should be strings instead -- they are not quoted in *.boot files.

So I fixed some of them.  If this is the correct approach, I can fix the remaining 200 or so.