### PR TITLE
disable GitHub linguist detection because it is inaccurate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+* -linguist-detectable


### PR DESCRIPTION
There was discussion in #53 and #58, the problem is that GitHub wrongly flags some source files to Clojure.

We didn't reach an agreement on how to flag our sources.

GitHub doesn't allow us to flag sources as we want.  And BOOT and SPAD are used only in FriCAS, so it is not qualified to put them into GitHub's language database either.

I think we can all agree on disable this inaccurate language detection statistics.  Have nothing is better than wrong and misleading.  We can add back proper support when things change.
