### PR TITLE
support older macOS versions

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -251,6 +251,7 @@ dist-osx-dmg: out-of-source-check
 	-rm -rf FriCAS.app FriCAS.dmg
 	${MKDIR_P} FriCAS.app/Contents/{MacOS,Resources}
 	${MAKE} DESTDIR=./FriCAS.app/Contents/Resources install-src
+	sed -e 's|/usr/local|`dirname $$0`/..|' -i .bak FriCAS.app/Contents/Resources/usr/local/bin/fricas
 	cp $(fricas_top_srcdir)/contrib/macos/Info.plist ./FriCAS.app/Contents/
 	cp $(fricas_top_srcdir)/contrib/macos/appIcon.icns ./FriCAS.app/Contents/Resources/
 	cc -framework CoreFoundation $(fricas_top_srcdir)/contrib/macos/FriCAS.c -o ./FriCAS.app/Contents/MacOS/FriCAS

--- a/contrib/macos/FriCAS.c
+++ b/contrib/macos/FriCAS.c
@@ -26,8 +26,7 @@ int main(int argc, const char *argv[]) {
 
   setenv("FRICAS_PREFIX", CFStringGetCStringPtr(path, encoding), 1);
 
-  system("open -a Terminal.app"
-         " -n --env FRICAS_PREFIX=\"${FRICAS_PREFIX}\""
+  system("open -a Terminal.app -n"
          " \"${FRICAS_PREFIX}/bin/fricas\"");
   return 0;
 }


### PR DESCRIPTION
This should fix https://github.com/fricas/fricas/issues/105.

Short summary: instead of using `open` to pass environment variable (which is not supported in older macOS versions), I use sed during install time to modify the `fricas` script to use its current directory instead of fixed `/usr/local`.