### PR TITLE
Introduced a way to hardcode SBCL_HOME

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -142,6 +142,9 @@ install-src:
 	echo FRICAS_VERSION='"${PACKAGE_VERSION}"' >> '${COMMAND}'.tmp
 	echo FRICAS_LISP_FLAVOR='"${FRICAS_LISP_FLAVOR}"' >> '${COMMAND}'.tmp
 	echo FRICAS_LISP_VERSION='"${FRICAS_LISP_VERSION}"' >> '${COMMAND}'.tmp
+	if test "x$(SBCL_HOME)" != "x" ; then \
+		echo export SBCL_HOME='"$${SBCL_HOME:-$(SBCL_HOME)}"' >> '${COMMAND}'.tmp ; \
+	fi
 	cat $(fricas_src_srcdir)/etc/fricas >> '${COMMAND}'.tmp
 	$(INSTALL_SCRIPT) '${COMMAND}'.tmp '${COMMAND}'
 	-rm '${COMMAND}'.tmp

--- a/config/var-def.mk
+++ b/config/var-def.mk
@@ -170,6 +170,8 @@ FASLEXT = @fricas_fasl_type2@
 FRICAS_LISP_FLAVOR=@fricas_lisp_flavor@
 FRICAS_LISP_VERSION=@fricas_lisp_version@
 
+SBCL_HOME=@sbcl_home@
+
 ##
 
 ##

--- a/configure
+++ b/configure
@@ -663,6 +663,7 @@ GMP_LIBDIR
 GMP_LDFLAGS
 GMP_CPPFLAGS
 GMP_WRAP_SO_TARGET
+sbcl_home
 SOLIB_FLAGS
 LIBSPAD_SO_TARGET
 fricas_lisp_version
@@ -752,6 +753,7 @@ enable_case_insensitive_file_system_check
 with_pre_generated
 with_lisp
 with_lisp_flavor
+with_sbcl_home
 with_gmp
 with_gmp_include
 with_gmp_lib
@@ -1419,6 +1421,7 @@ Optional Packages:
                           code.
   --with-lisp=L           use L as Lisp platform
   --with-lisp-flavor=F    obsolete and ignored
+  --with-sbcl-home=PATH   specify the path of hardcoded SBCL_HOME
   --with-gmp=PATH         specify prefix directory for the installed GMP
                           package. Equivalent to
                           --with-gmp-include=PATH/include plus
@@ -4199,6 +4202,17 @@ case $target in
        SOLIB_FLAGS="-shared"
          ;;
 esac
+
+
+
+## Configure desired SBCL_HOME
+
+# Check whether --with-sbcl-home was given.
+if test "${with_sbcl_home+set}" = set; then :
+  withval=$with_sbcl_home; sbcl_home=$withval
+else
+  sbcl_home=""
+fi
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -325,6 +325,13 @@ esac
 AC_SUBST(LIBSPAD_SO_TARGET)
 AC_SUBST(SOLIB_FLAGS)
 
+## Configure desired SBCL_HOME
+AC_ARG_WITH([sbcl-home],
+    AS_HELP_STRING([--with-sbcl-home=PATH], [specify the path of hardcoded SBCL_HOME]),
+    sbcl_home=$withval,
+    sbcl_home="")
+AC_SUBST(sbcl_home)
+
 ## In case our underlying lisp is SBCL or Closure CL, we provide a
 ## wrapper to enable GMP bignums in lisp
 GMP_WRAP_SO_TARGET=""


### PR DESCRIPTION
I've added a configure argument `--with-sbcl-home` which allows to specify desired `SBCL_HOME`.

Without it fricas' lisp can't be really used without specification of `SBCL_HOME` environment variable at some cases that leads to wired issue like:
```
(1) -> )lisp (require :asdf)

   >> System error:
   Don't know how to REQUIRE ASDF.
See also:
  The SBCL Manual, Variable SB-EXT:*MODULE-PROVIDER-FUNCTIONS*
  The SBCL Manual, Function REQUIRE

(1) ->
```