### PR TITLE
generate helpfiles also if "-with-x=no" is active

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -8,7 +8,7 @@ subdir = src/
 
 all: all-ax
 
-all-ax all-src: stamp
+all-ax all-src: copy-helpfiles stamp
 	@echo finished $(builddir)
 
 stamp: @fricas_src_all@
@@ -33,6 +33,8 @@ all-hyper: all-lib all-sman all-graph
 	cd hyper && ${MAKE}
 all-doc: all-hyper all-fricassys
 	cd doc && ${MAKE}
+copy-helpfiles:
+	cd doc && ${MAKE} copy-helpfiles
 all-lib:
 	@cd lib && ${MAKE}
 all-lisp: all-lib


### PR DESCRIPTION
Before this commit, *.help files are not generated if either X is not available or --with-x=no is given to the configure script although the generation of *.help files does not depend on X.

The commit generates *.help files unconditionally.