### PR TITLE
Aldor tests

### DIFF
--- a/src/aldor/Makefile3.in
+++ b/src/aldor/Makefile3.in
@@ -33,11 +33,17 @@ $(runtime_files): lib/%.$(FASLEXT): tmp/mko_%.lsp lsp/%.lsp lib/.dir
 	$(INTERPSYS) < $< > tmp/mko_$*.log
 	test -f $@
 
+build_runtime_files := $(foreach i,$(runtime_files), $(fricas_targetdir)/aldor/$(i))
+
+$(build_runtime_files): $(fricas_targetdir)/aldor/% : %
+	mkdir -p $$(dirname $@)
+	cp $< $@
+
 tmp/mko_%.lsp: tmp/.dir
 	echo ')lisp (compile-file "$(abs_builddir)/lsp/$*.lsp" :output-file "$(abs_builddir)/lib/$*.$(FASLEXT)")' > $@
 	echo ')lisp (quit)' >> $@
 
-runtimefiles: $(runtime_files)
+runtimefiles: $(runtime_files) $(build_runtime_files)
 
 
 #

--- a/src/input/Makefile.in
+++ b/src/input/Makefile.in
@@ -181,3 +181,34 @@ ${OUTS} ${REGRESS} : %.output: $(srcdir)/%.input
 	echo ')read "tmp'$$$$'.input"' | \
 	FRICAS_INITFILE='' ${TESTSYS} > $*.output 2>&1 ; \
 	rm tmp$$$$.input )
+
+ifeq (@BUILD_ALDOR_INTERFACE@,yes)
+top_srcdir=@top_srcdir@
+%.as: ${IN}/%.as
+	cp $< $@
+
+aldor_sieve.output: sieve.as
+
+ALDOR_REGRESS = aldor_sieve.output
+ALDOR_ARGS = -O -Fasy -Flsp -lfricas -Y ../aldor/al -I $(top_srcdir)/src/aldor/aldor
+
+aldor-regression-tests: $(ALDOR_REGRESS)
+aldor-check: aldor-regression-tests
+	awk -f $(srcdir)/check_result $(ALDOR_REGRESS)
+
+aldor-clean:
+	rm -f $(ALDOR_REGRESS)
+
+${ALDOR_REGRESS}: %.output: $(srcdir)/%.input Makefile
+	( \
+	echo running aldor test file $* ; \
+	echo ')set message test off' > tmp$$$$.input; \
+	echo ')set message auto on' >> tmp$$$$.input ; \
+	echo ')set compiler args "$(ALDOR_ARGS)"' > tmp$$$$.input ; \
+	echo 'systemCommand "read $<"' >> tmp$$$$.input ; \
+	echo ')lisp (quit)' >> tmp$$$$.input ; \
+	echo ')read "tmp'$$$$'.input"' | \
+	ALDOR_COMPILER='@ALDOR@' FRICAS_INITFILE='' ${TESTSYS} > $*.output 2>&1 ; \
+	rm tmp$$$$.input )
+
+endif

--- a/src/input/aldor_sieve.input
+++ b/src/input/aldor_sieve.input
@@ -1,0 +1,18 @@
+)set bre resume
+
+)co sieve.as
+
+)expose UnittestCount UnittestAux Unittest
+testsuite "AldorSmoke"
+testcase "AldorSmoke1"
+
+ee := 8
+ss := sieve 22
+testEquals(8, sieve 22)
+
+expected() ==
+    messagePrint("testsuite | testcases: failed (total) | tests: failed (total)")$OutputForm
+    messagePrint("AldorSmoke                  0     (1)               0     (0)")$OutputForm
+
+statistics()
+expected()

--- a/src/input/sieve.as
+++ b/src/input/sieve.as
@@ -1,0 +1,21 @@
+--
+-- sieve.as: A prime number sieve to count primes <= n.
+--
+#include "fricas"
+
+N ==> NonNegativeInteger;
+import from Boolean, N, Integer;
+
+sieve(n: N): N  == {
+        isprime: PrimitiveArray Boolean := new(n+1, true);
+
+        np: N := 0;
+        two: N := 2;
+        for p in two..n | isprime(p::Integer) repeat {
+                np := np + 1;
+                for i in two*p..n by p::Integer repeat {
+                        isprime(i::Integer) := false;
+                }
+        }
+        np
+}


### PR DESCRIPTION
A short patch that adds a smoke test for aldor connectivity.  The plan is to add a few more, but it makes sense to start with a small set.

To use, run make aldor-check in the src/input directory.  Note that it is not part of the normal 'make check' testsuite; it can be, but I'll leave that for others to decide.
