### PR TITLE
Collect GC time for supported Lisps

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-10-26  Qian Yun  <oldk1331@gmail.com>
+
+	* src/lisp/fricas-lisp.lisp: Collect GC time for supported Lisps
+
 2023-10-20  Qian Yun  <oldk1331@gmail.com>
 
 	* src/algebra/irexpand.spad: Slightly improve 'tantrick'

--- a/src/lisp/fricas-lisp.lisp
+++ b/src/lisp/fricas-lisp.lisp
@@ -1151,10 +1151,15 @@ with this hack and will try to convince the GCL crowd to fix this.
 (defmacro |replaceString| (result part start)
     `(replace ,result ,part :start1 ,start))
 
-#+:GCL
-(defmacro |elapsedGcTime| () '(system:gbc-time))
-#-:GCL
-(defmacro |elapsedGcTime| () '0)
+(defun |elapsedGcTime| ()
+  #+:clisp
+  (multiple-value-bind (used room static gc-count gc-space gc-time) (sys::%room)
+    gc-time)
+  #+:cmu ext:*gc-run-time*
+  #+:gcl (system:gbc-time)
+  #+:openmcl (ccl:gctime)
+  #+:sbcl sb-ext:*gc-run-time*
+  #-(or :clisp :cmu :gcl :openmcl :sbcl) 0)
 
 (defmacro |char| (arg)
   (cond ((stringp arg) (character arg))


### PR DESCRIPTION
This patch adds support for tracking GC time for various Lisps in FriCAS.