### PR TITLE
Fix collection and report of memory usage

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-11-04  Qian Yun  <oldk1331@gmail.com>
+
+	* src/interp/g-timer.boot, src/interp/setvart.boot,
+	src/interp/macros.lisp, src/interp/setq.lisp:
+	Enable memory usage report: ')set message storage on'
+
 2023-10-30  Waldek Hebisch  <cas@fricas.org>
 
 	* src/lisp/Makefile.in: Use large memory model for GCL

--- a/src/interp/macros.lisp
+++ b/src/interp/macros.lisp
@@ -675,7 +675,15 @@ This function respects intermediate #\Newline characters and drops
 
 (defun WHOCALLED(n) nil) ;; no way to look n frames up the stack
 
-(defun heapelapsed () 0)
+(defun heapelapsed ()
+  #+:clisp
+  (multiple-value-bind (used room static gc-count gc-space gc-time) (sys::%room)
+    (+ used gc-space))
+  #+:cmu (ext:get-bytes-consed)
+  #+:ecl (si:gc-stats t)
+  #+:openmcl (ccl::total-bytes-allocated)
+  #+:sbcl (sb-ext:get-bytes-consed)
+  #-(or :clisp :cmu :ecl :openmcl :sbcl) 0)
 
 (defun |goGetTracerHelper| (dn f oname alias options modemap)
     (lambda(&rest l)

--- a/src/interp/setq.lisp
+++ b/src/interp/setq.lisp
@@ -317,7 +317,7 @@
    |UnionCategory|
       ))
 
-(SETQ |$printStorageIfTrue| NIL) ;; storage info disabled in common lisp
+(SETQ |$printStorageIfTrue| NIL)
 (SETQ |$noEnv| NIL)
 
 (SETQ |$SideEffectFreeFunctionList| '(

--- a/src/interp/setvart.boot
+++ b/src/interp/setvart.boot
@@ -381,6 +381,13 @@ DEFPARAMETER($setOptions, '(
       $displayStartMsgs
       (on off)
       on)
+     (storage
+      "print memory usage after computation"
+      interpreter
+      LITERALS
+      $printStorageIfTrue
+      (on off)
+      off)
      (testing
       "print system testing header"
       development


### PR DESCRIPTION
This patch will allow FriCAS to collect and report memory usage during computation.

Currently there is no toplevel settings to enable it, you shall use
````
)lisp (setq |$printStorageIfTrue| t)
````

For example:
````
(1) -> [x for x in 1..1000];

                                                  Type: List(PositiveInteger)
             Storage: 0 (IN) + 450,544 (EV) + 0 (OT) + 0 (GC) = 450,544 bytes
````