### PR TITLE
Update naalgc.spad documentation display

### DIFF
--- a/src/algebra/naalgc.spad
+++ b/src/algebra/naalgc.spad
@@ -6,11 +6,11 @@
 ++ AMS Classifications:
 ++ Keywords: Magma,  binary operation
 ++ Reference:
-++  N. Jacobson: Structure and Representations of Jordan Algebras
-++  AMS, Providence, 1968
+++   N. Jacobson: Structure and Representations of Jordan Algebras
+++   AMS, Providence, 1968
 ++ Description:
-++  Magma is the class of all multiplicative magmas, i.e. sets
-++  with a binary operation.
+++   Magma is the class of all multiplicative magmas, i.e. sets
+++   with a binary operation.
 Magma() : Category == SetCategory with
     --operations
       "*": (%, %) -> %
@@ -50,22 +50,22 @@ Magma() : Category == SetCategory with
 ++ Keywords:
 ++ Keywords: Magma with unit, binary operation
 ++ Reference:
-++  N. Jacobson: Structure and Representations of Jordan Algebras
-++  AMS, Providence, 1968
+++   N. Jacobson: Structure and Representations of Jordan Algebras
+++   AMS, Providence, 1968
 ++ Description:
-++  MagmaWithUnit is the class of multiplicative monads with unit,
-++  i.e. sets with a binary operation and a unit element.
+++   MagmaWithUnit is the class of multiplicative monads with unit,
+++   i.e. sets with a binary operation and a unit element.
 ++ Axioms
-++    leftIdentity("*" : (%, %) -> %, 1)   \tab{30} 1 * x = x
-++    rightIdentity("*" : (%, %) -> %, 1)  \tab{30} x * 1 = x
+++   leftIdentity("*" : (%, %) -> %, 1)   \tab{30} 1 * x = x
+++   rightIdentity("*" : (%, %) -> %, 1)  \tab{30} x * 1 = x
 ++ Common Additional Axioms
-++    unitsKnown---if "recip" says "failed", that PROVES input wasn't a unit
+++   unitsKnown --- if "recip" says "failed" then that PROVES input wasn't a unit
 MagmaWithUnit() : Category == Magma with
     --constants
       1 : constant ->  %
         ++ \spad{1} returns the unit element, denoted by \spad{1}.
       sample : constant -> %               
-        ++ \spad{sample} yields a value of type \spadtype{%}
+        ++ \spadfun{sample} yields a value of type \spadtype{%}
     --operations
       one? : % -> Boolean
         ++ \spad{one?(a)} tests whether \spad{a} is the unit \spad{1}.
@@ -81,9 +81,8 @@ MagmaWithUnit() : Category == Magma with
         ++ \spad{a ^ n} returns the \spad{n}-th power of \spad{a},
         ++ defined by repeated squaring.
       recip : % -> Union(%, "failed")
-        ++ \spad{recip(a)} returns an element, which is both a left and a right
-        ++ inverse of \spad{a},
-        ++ or \spad{"failed"} if such an element doesn't exist or cannot
+        ++ \spad{recip(a)} returns an element, which is both a left and a right inverse
+        ++ of \spad{a}, or \spad{"failed"} if such an element doesn't exist or cannot
         ++ be determined (see unitsKnown).
       leftRecip : % -> Union(%, "failed")
         ++ \spad{leftRecip(a)} returns an element, which is a left inverse of \spad{a},
@@ -124,8 +123,8 @@ MagmaWithUnit() : Category == Magma with
 )abbrev category NASRNG NonAssociativeSemiRng
 ++ Author: Waldek Hebisch
 ++ Description:
-++  The category of semirings, not necessarily associative,
-++  not necessarily commutative, and not necessarily with a 1.
+++   The category of semirings, not necessarily associative,
+++   not necessarily commutative, and not necessarily with a 1.
 NonAssociativeSemiRng() : Category == Join(AbelianSemiGroup, Magma) with
     antiCommutator : (%, %) -> %
       ++ \spad{antiCommutator(a, b)} returns \spad{a * b + b * a}.
@@ -135,8 +134,8 @@ NonAssociativeSemiRng() : Category == Join(AbelianSemiGroup, Magma) with
 )abbrev category NASRING NonAssociativeSemiRing
 ++ Author: Waldek Hebisch
 ++ Description:
-++  The category of semirings, not necessarily associative,
-++  not necessarily commutative, with 0 and 1.
+++   The category of semirings, not necessarily associative,
+++   not necessarily commutative, with 0 and 1.
 NonAssociativeSemiRing() : Category == Join(NonAssociativeSemiRng,
     AbelianMonoid, MagmaWithUnit)
 
@@ -148,16 +147,16 @@ NonAssociativeSemiRing() : Category == Join(NonAssociativeSemiRng,
 ++ AMS Classifications:
 ++ Keywords: not associative ring
 ++ Reference:
-++  R.D. Schafer: An Introduction to Nonassociative Algebras
-++  Academic Press, New York, 1966
+++   R.D. Schafer: An Introduction to Nonassociative Algebras
+++   Academic Press, New York, 1966
 ++ Description:
-++  NonAssociativeRng is a basic ring-type structure, not necessarily
-++  commutative or associative, and not necessarily with unit.
-++  Axioms
+++   NonAssociativeRng is a basic ring-type structure, not necessarily
+++   commutative or associative, and not necessarily with unit.
+++ Axioms:
 ++    x * (y + z) = x * y + x * z
 ++    (x + y) * z = x * z + y * z
-++  Common Additional Axioms
-++    noZeroDivisors  a b = 0 => a = 0 or b = 0
+++ Common Additional Axioms:
+++   noZeroDivisors  a b = 0 => a = 0 or b = 0
 NonAssociativeRng() : Category == Join(NonAssociativeSemiRng,
                                        AbelianGroup)  with
     associator : (%, %, %) -> %
@@ -176,11 +175,11 @@ NonAssociativeRng() : Category == Join(NonAssociativeSemiRng,
 ++ AMS Classifications:
 ++ Keywords: non-associative ring with unit
 ++ Reference:
-++  R.D. Schafer: An Introduction to Nonassociative Algebras
-++  Academic Press, New York, 1966
+++   R.D. Schafer: An Introduction to Nonassociative Algebras
+++   Academic Press, New York, 1966
 ++ Description:
-++  A NonAssociativeRing is a non associative rng which has a unit,
-++  the multiplication is not necessarily commutative or associative.
+++   A NonAssociativeRing is a non associative rng which has a unit,
+++   the multiplication is not necessarily commutative or associative.
 NonAssociativeRing() : Category == Join(NonAssociativeRng,
                                         NonAssociativeSemiRing) with
     --operations
@@ -202,20 +201,20 @@ NonAssociativeRing() : Category == Join(NonAssociativeRng,
 ++ AMS Classifications:
 ++ Keywords: nonassociative algebra
 ++ Reference:
-++  R.D. Schafer: An Introduction to Nonassociative Algebras
-++  Academic Press, New York, 1966
+++   R.D. Schafer: An Introduction to Nonassociative Algebras
+++   Academic Press, New York, 1966
 ++ Description:
 ++   NonAssociativeAlgebra is the category of non associative algebras
 ++   (modules which are themselves non associative rngs).
-++   Axioms
-++      r*(a*b) = (r*a)*b = a*(r*b)
+++ Axioms:
+++   r * (a * b) = (r * a) * b = a * (r * b)
 NonAssociativeAlgebra(R : CommutativeRing) : Category == _
   Join(NonAssociativeRng, Module R) with
     --operations
     plenaryPower : (%, PositiveInteger) -> %
-      ++ plenaryPower(a, n) is recursively defined to be
-      ++ \spad{plenaryPower(a, n-1)*plenaryPower(a, n-1)} for \spad{n>1}
-      ++ and \spad{a} for \spad{n=1}.
+      ++ \spad{plenaryPower(a, n)} is recursively defined to be
+      ++ \spad{plenaryPower(a, n - 1) * plenaryPower(a, n - 1)} for \spad{n > 1}
+      ++ and \spad{a} for \spad{n = 1}.
   add
     plenaryPower(a, n) ==
       ( n = 1 ) => a
@@ -243,79 +242,79 @@ NonAssociativeAlgebra(R : CommutativeRing) : Category == _
 FiniteRankNonAssociativeAlgebra(R : CommutativeRing):
  Category == NonAssociativeAlgebra R with
     someBasis : () -> Vector %
-      ++ someBasis() returns some \spad{R}-module basis.
+      ++ \spad{someBasis()} returns some \spad{R}-module basis.
     rank : () -> PositiveInteger
-      ++ rank() returns the rank of the algebra as \spad{R}-module.
+      ++ \spad{rank()} returns the rank of the algebra as \spad{R}-module.
     conditionsForIdempotents : Vector % -> List Polynomial R
-      ++ conditionsForIdempotents([v1, ..., vn]) determines a complete list
+      ++ \spad{conditionsForIdempotents([v1, ..., vn])} determines a complete list
       ++ of polynomial equations for the coefficients of idempotents
       ++ with respect to the \spad{R}-module basis \spad{v1}, ..., \spad{vn}.
     structuralConstants : Vector % -> Vector Matrix R
-      ++ structuralConstants([v1, v2, ..., vm]) calculates the structural
-      ++ constants \spad{[(gammaijk) for k in 1..m]} defined by
+      ++ \spad{structuralConstants([v1, v2, ..., vm])} calculates the structural
+      ++ constants \spad{[(gammaijk) for k in 1 .. m]} defined by
       ++ \spad{vi * vj = gammaij1 * v1 + ... + gammaijm * vm},
       ++ where \spad{[v1, ..., vm]} is an \spad{R}-module basis
       ++ of a subalgebra.
     leftRegularRepresentation : (% , Vector %) -> Matrix R
-      ++ leftRegularRepresentation(a, [v1, ..., vn]) returns the matrix
+      ++ \spad{leftRegularRepresentation(a, [v1, ..., vn])} returns the matrix
       ++ \spad{m} of the linear map defined by left multiplication
       ++ by \spad{a} with respect to the \spad{R}-module basis
       ++ \spad{b = [v1, ..., vn]}.  That is for all \spad{x}
-      ++ \spad{coordinates(a*x, b) = m*coordinates(x, b)}.
+      ++ \spad{coordinates(a * x, b) = m * coordinates(x, b)}.
     rightRegularRepresentation : (% , Vector %) -> Matrix R
-      ++ rightRegularRepresentation(a, [v1, ..., vn]) returns the matrix
+      ++ \spad{rightRegularRepresentation(a, [v1, ..., vn])} returns the matrix
       ++ \spad{m} of the linear map defined by right multiplication
       ++ by \spad{a} with respect to the \spad{R}-module basis
       ++ \spad{b = [v1, ..., vn]}.  That is for all \spad{x}
-      ++ \spad{coordinates(x*a, b) = m*coordinates(x, b)}.
+      ++ \spad{coordinates(x * a, b) = m * coordinates(x, b)}.
     leftTrace : %  -> R
-      ++ leftTrace(a) returns the trace of the left regular representation
+      ++ \spad{leftTrace(a)} returns the trace of the left regular representation
       ++ of \spad{a}.
     rightTrace : %  -> R
-      ++ rightTrace(a) returns the trace of the right regular representation
+      ++ \spad{rightTrace(a)} returns the trace of the right regular representation
       ++ of \spad{a}.
     leftNorm : %  -> R
-      ++ leftNorm(a) returns the determinant of the left regular representation
+      ++ \spad{leftNorm(a)} returns the determinant of the left regular representation
       ++ of \spad{a}.
     rightNorm : %  -> R
-      ++ rightNorm(a) returns the determinant of the right regular
+      ++ \spad{rightNorm(a)} returns the determinant of the right regular
       ++ representation of \spad{a}.
     coordinates : (%, Vector %) -> Vector R
-      ++ coordinates(a, [v1, ..., vn]) returns the coordinates of \spad{a}
+      ++ \spad{coordinates(a, [v1, ..., vn])} returns the coordinates of \spad{a}
       ++ with respect to the \spad{R}-module basis \spad{v1}, ..., \spad{vn}.
     coordinates : (Vector %, Vector %) -> Matrix R
-      ++ coordinates([a1, ..., am], [v1, ..., vn]) returns a matrix whose
+      ++ \spad{coordinates([a1, ..., am], [v1, ..., vn])} returns a matrix whose
       ++ i-th row is formed by the coordinates of \spad{ai}
       ++ with respect to the \spad{R}-module basis \spad{v1}, ..., \spad{vn}.
     represents : (Vector R, Vector %) -> %
-      ++ represents([a1, ..., am], [v1, ..., vm]) returns the linear
-      ++ combination \spad{a1*vm + ... + an*vm}.
+      ++ \spad{represents([a1, ..., am], [v1, ..., vm])} returns the linear
+      ++ combination \spad{a1 * vm + ... + an * vm}.
     leftDiscriminant : Vector % -> R
-      ++ leftDiscriminant([v1, ..., vn]) returns  the determinant of the
+      ++ \spad{leftDiscriminant([v1, ..., vn])} returns  the determinant of the
       ++ \spad{n}-by-\spad{n} matrix whose element at the \spad{i}-th row
       ++ and \spad{j}-th column is given by the left trace of the product
-      ++ \spad{vi*vj}.
+      ++ \spad{vi * vj}.
       ++ Note: the same as \spad{determinant(leftTraceMatrix([v1, ..., vn]))}.
     rightDiscriminant : Vector % -> R
-      ++ rightDiscriminant([v1, ..., vn]) returns  the determinant of the
+      ++ \spad{rightDiscriminant([v1, ..., vn])} returns  the determinant of the
       ++ \spad{n}-by-\spad{n} matrix whose element at the \spad{i}-th row
       ++ and \spad{j}-th column is given by the right trace of the product
-      ++ \spad{vi*vj}.
+      ++ \spad{vi * vj}.
       ++ Note: the same as \spad{determinant(rightTraceMatrix([v1, ..., vn]))}.
     leftTraceMatrix : Vector % -> Matrix R
-      ++ leftTraceMatrix([v1, ..., vn]) is the \spad{n}-by-\spad{n} matrix
+      ++ \spad{leftTraceMatrix([v1, ..., vn])} is the \spad{n}-by-\spad{n} matrix
       ++ whose element at the \spad{i}-th row and \spad{j}-th column is given
-      ++ by the left trace of the product \spad{vi*vj}.
+      ++ by the left trace of the product \spad{vi * vj}.
     rightTraceMatrix : Vector % -> Matrix R
-      ++ rightTraceMatrix([v1, ..., vn]) is the \spad{n}-by-\spad{n} matrix
+      ++ \spad{rightTraceMatrix([v1, ..., vn])} is the \spad{n}-by-\spad{n} matrix
       ++ whose element at the \spad{i}-th row and \spad{j}-th column is given
-      ++ by the right trace of the product \spad{vi*vj}.
+      ++ by the right trace of the product \spad{vi * vj}.
     leftCharacteristicPolynomial : % -> SparseUnivariatePolynomial R
-      ++ leftCharacteristicPolynomial(a) returns the characteristic
+      ++ \spad{leftCharacteristicPolynomial(a)} returns the characteristic
       ++ polynomial of the left regular representation of \spad{a}
       ++ with respect to any basis.
     rightCharacteristicPolynomial : % -> SparseUnivariatePolynomial R
-      ++ rightCharacteristicPolynomial(a) returns the characteristic
+      ++ \spad{rightCharacteristicPolynomial(a)} returns the characteristic
       ++ polynomial of the right regular representation of \spad{a}
       ++ with respect to any basis.
 
@@ -324,86 +323,85 @@ FiniteRankNonAssociativeAlgebra(R : CommutativeRing):
     --if R has CharacteristicNonZero then CharacteristicNonZero
 
     commutative? : ()-> Boolean
-      ++ commutative?() tests if multiplication in the algebra
+      ++ \spad{commutative?()} tests if multiplication in the algebra
       ++ is commutative.
     antiCommutative? : ()-> Boolean
-      ++ antiCommutative?() tests if \spad{a*a = 0}
+      ++ \spad{antiCommutative?()} tests if \spad{a * a = 0}
       ++ for all \spad{a} in the algebra.
-      ++ Note: this implies \spad{a*b + b*a = 0} for all \spad{a} and \spad{b}.
+      ++ Note: this implies \spad{a * b + b * a = 0} for all \spad{a} and \spad{b}.
     associative? : ()-> Boolean
-      ++ associative?() tests if multiplication in algebra
+      ++ \spad{associative?()} tests if multiplication in algebra
       ++ is associative.
     antiAssociative? : ()-> Boolean
-      ++ antiAssociative?() tests if multiplication in algebra
-      ++ is anti-associative, i.e. \spad{(a*b)*c + a*(b*c) = 0}
-      ++ for all \spad{a}, b, c in the algebra.
+      ++ \spad{antiAssociative?()} tests if multiplication in algebra
+      ++ is anti-associative, i.e. \spad{(a * b) * c + a * (b * c) = 0}
+      ++ for all \spad{a}, \spad{b}, \spad{c} in the algebra.
     leftAlternative? : ()-> Boolean
-      ++ leftAlternative?() tests if \spad{2*associator(a, a, b) = 0}
+      ++ \spad{leftAlternative?()} tests if \spad{2 * associator(a, a, b) = 0}
       ++ for all \spad{a}, b in the algebra.
       ++ Note: we only can test this; in general we don't know
-      ++ whether \spad{2*a=0} implies \spad{a=0}.
+      ++ whether \spad{2 * a = 0} implies \spad{a = 0}.
     rightAlternative? : ()-> Boolean
-      ++ rightAlternative?() tests if \spad{2*associator(a, b, b) = 0}
+      ++ \spad{rightAlternative?()} tests if \spad{2 * associator(a, b, b) = 0}
       ++ for all \spad{a}, b in the algebra.
       ++ Note: we only can test this; in general we don't know
-      ++ whether \spad{2*a=0} implies \spad{a=0}.
+      ++ whether \spad{2 * a = 0} implies \spad{a = 0}.
     flexible? : ()->  Boolean
-      ++ flexible?() tests if \spad{2*associator(a, b, a) = 0}
+      ++ \spad{flexible?()} tests if \spad{2 * associator(a, b, a) = 0}
       ++ for all \spad{a}, b in the algebra.
       ++ Note: we only can test this; in general we don't know
-      ++ whether \spad{2*a=0} implies \spad{a=0}.
+      ++ whether \spad{2 * a = 0} implies \spad{a = 0}.
     alternative? : ()-> Boolean
-      ++ alternative?() tests if
-      ++ \spad{2*associator(a, a, b) = 0 = 2*associator(a, b, b)}
+      ++ \spad{alternative?()} tests if \spad{2 * associator(a, a, b) = 0 = 2 * associator(a, b, b)}
       ++ for all \spad{a}, b in the algebra.
       ++ Note: we only can test this; in general we don't know
-      ++ whether \spad{2*a=0} implies \spad{a=0}.
+      ++ whether \spad{2 * a = 0} implies \spad{a = 0}.
     powerAssociative? : ()-> Boolean
-      ++ powerAssociative?() tests if all subalgebras
+      ++ \spad{powerAssociative?()} tests if all subalgebras
       ++ generated by a single element are associative.
     jacobiIdentity? : () -> Boolean
-      ++ jacobiIdentity?() tests if \spad{(a*b)*c + (b*c)*a + (c*a)*b = 0}
-      ++ for all \spad{a}, b, c in the algebra. For example, this holds
+      ++ \spad{jacobiIdentity?()} tests if \spad{(a * b) * c + (b * c) * a + (c * a) * b = 0}
+      ++ for all \spad{a}, \spad{b}, \spad{c} in the algebra. For example, this holds
       ++ for crossed products of 3-dimensional vectors.
     lieAdmissible? : () -> Boolean
-      ++ lieAdmissible?() tests if the algebra defined by the commutators
+      ++ \spad{lieAdmissible?()} tests if the algebra defined by the commutators
       ++ is a Lie algebra, i.e. satisfies the Jacobi identity.
       ++ The property of anticommutativity follows from definition.
     jordanAdmissible? : () -> Boolean
-      ++ jordanAdmissible?() tests if 2 is invertible in the
+      ++ \spad{jordanAdmissible?()} tests if 2 is invertible in the
       ++ coefficient domain and the multiplication defined by
-      ++ \spad{(1/2)(a*b+b*a)} determines a
+      ++ \spad{(1 / 2) (a * b + b * a)} determines a
       ++ Jordan algebra, i.e. satisfies the Jordan identity.
       ++ The property of \spadtype{CommutativeStar}
       ++ follows from by definition.
     noncommutativeJordanAlgebra? : () -> Boolean
-      ++ noncommutativeJordanAlgebra?() tests if the algebra
+      ++ \spad{noncommutativeJordanAlgebra?()} tests if the algebra
       ++ is flexible and Jordan admissible.
     jordanAlgebra? : () -> Boolean
-      ++ jordanAlgebra?() tests if the algebra is commutative,
-      ++ characteristic is not 2, and \spad{(a*b)*a^2 - a*(b*a^2) = 0}
+      ++ \spad{jordanAlgebra?()} tests if the algebra is commutative,
+      ++ characteristic is not 2, and \spad{(a * b) * a ^ 2 - a * (b * a ^ 2) = 0}
       ++ for all \spad{a}, b, c in the algebra (Jordan identity).
       ++ Example:
       ++ for every associative algebra \spad{(A, +, @)} we can construct a
-      ++ Jordan algebra \spad{(A, +, *)}, where \spad{a*b := (a@b+b@a)/2}.
+      ++ Jordan algebra \spad{(A, +, *)}, where \spad{a * b := (a @ b + b @ a) / 2}.
     lieAlgebra? : () -> Boolean
-      ++ lieAlgebra?() tests if the algebra is anticommutative
-      ++ and \spad{(a*b)*c + (b*c)*a + (c*a)*b = 0}
-      ++ for all \spad{a}, b, c in the algebra (Jacobi identity).
+      ++ \spad{lieAlgebra?()} tests if the algebra is anticommutative
+      ++ and \spad{(a * b) * c + (b * c) * a + (c * a) * b = 0}
+      ++ for all \spad{a}, \spad{b}, \spad{c} in the algebra (Jacobi identity).
       ++ Example:
       ++ for every associative algebra \spad{(A, +, @)} we can construct a
-      ++ Lie algebra \spad{(A, +, *)}, where \spad{a*b := a@b-b@a}.
+      ++ Lie algebra \spad{(A, +, *)}, where \spad{a * b := a @ b - b @ a}.
 
     if R has IntegralDomain then
       -- we not necessarily have a unit, hence we don't inherit
       -- the next 3 functions and hence copy them from MagmaWithUnit:
       recip : % -> Union(%,"failed")
-        ++ recip(a) returns an element, which is both a left and a right
+        ++ \spad{recip(a)} returns an element, which is both a left and a right
         ++ inverse of \spad{a},
         ++ or \spad{"failed"} if there is no unit element, if such an
         ++ element doesn't exist or cannot be determined (see unitsKnown).
       leftRecip : % -> Union(%,"failed")
-        ++ leftRecip(a) returns an element, which is a left inverse of \spad{a},
+        ++ \spad{leftRecip(a)} returns an element, which is a left inverse of \spad{a},
         ++ or \spad{"failed"} if there is no unit element, if such an
         ++ element doesn't exist or cannot be determined (see unitsKnown).
       rightRecip : % -> Union(%,"failed")

--- a/src/algebra/naalgc.spad
+++ b/src/algebra/naalgc.spad
@@ -405,41 +405,39 @@ FiniteRankNonAssociativeAlgebra(R : CommutativeRing):
         ++ or \spad{"failed"} if there is no unit element, if such an
         ++ element doesn't exist or cannot be determined (see unitsKnown).
       rightRecip : % -> Union(%,"failed")
-        ++ rightRecip(a) returns an element, which is a right inverse of
-        ++ \spad{a},
-        ++ or \spad{"failed"} if there is no unit element, if such an
+        ++ \spad{rightRecip(a)} returns an element, which is a right inverse of
+        ++ \spad{a}, or \spad{"failed"} if there is no unit element, if such an
         ++ element doesn't exist or cannot be determined (see unitsKnown).
       associatorDependence : () -> List Vector R
-        ++ associatorDependence() looks for the associator identities, i.e.
+        ++ \s[ad{associatorDependence()} looks for the associator identities, i.e.
         ++ finds a basis of the solutions of the linear combinations of the
-        ++ six permutations of \spad{associator(a, b, c)} which yield 0,
-        ++ for all \spad{a}, b, c in the algebra.
+        ++ six permutations of \spad{associator(a, b, c)} which yield \spad{0},
+        ++ for all \spad{a}, \spad{b}, \spad{c} in the algebra.
         ++ The order of the permutations is \spad{123 231 312 132 321 213}.
       leftMinimalPolynomial : % -> SparseUnivariatePolynomial R
-        ++ leftMinimalPolynomial(a) returns the polynomial determined by the
+        ++ \spad{leftMinimalPolynomial(a)} returns the polynomial determined by the
         ++ smallest non-trivial linear combination of left powers of \spad{a}.
         ++ Note: the polynomial never has a constant term as in general
         ++ the algebra has no unit.
       rightMinimalPolynomial : % -> SparseUnivariatePolynomial R
-        ++ rightMinimalPolynomial(a) returns the polynomial determined by the
-        ++ smallest non-trivial linear
-        ++ combination of right powers of \spad{a}.
+        ++ \spad{rightMinimalPolynomial(a)} returns the polynomial determined by the
+        ++ smallest non-trivial linear combination of right powers of \spad{a}.
         ++ Note: the polynomial never has a constant term as in general
         ++ the algebra has no unit.
       leftUnits:() -> Union(Record(particular: %, basis: List %), "failed")
-        ++ leftUnits() returns the affine space of all left units of the
+        ++ \spad{leftUnits()} returns the affine space of all left units of the
         ++ algebra, or \spad{"failed"} if there is none.
       rightUnits:() -> Union(Record(particular: %, basis: List %), "failed")
-        ++ rightUnits() returns the affine space of all right units of the
+        ++ \spad{rightUnits()} returns the affine space of all right units of the
         ++ algebra, or \spad{"failed"} if there is none.
       leftUnit:() -> Union(%, "failed")
-        ++ leftUnit() returns a left unit of the algebra
+        ++ \spad{leftUnit()} returns a left unit of the algebra
         ++ (not necessarily unique), or \spad{"failed"} if there is none.
       rightUnit:() -> Union(%, "failed")
-        ++ rightUnit() returns a right unit of the algebra
+        ++ \spad{rightUnit()} returns a right unit of the algebra
         ++ (not necessarily unique), or \spad{"failed"} if there is none.
       unit:() -> Union(%, "failed")
-        ++ unit() returns a unit of the algebra (necessarily unique),
+        ++ \spad{unit()} returns a unit of the algebra (necessarily unique),
         ++ or \spad{"failed"} if there is none.
       -- we not necessarily have a unit, hence we can't say anything
       -- about characteristic
@@ -447,8 +445,7 @@ FiniteRankNonAssociativeAlgebra(R : CommutativeRing):
       -- if R has CharacteristicNonZero then CharacteristicNonZero
       unitsKnown
         ++ unitsKnown means that \spadfun{recip} truly yields reciprocal
-        ++ or \spad{"failed"} if not a unit,
-        ++ similarly for \spadfun{leftRecip} and
+        ++ or \spad{"failed"} if not a unit, similarly for \spadfun{leftRecip} and
         ++ \spadfun{rightRecip}. The reason is that we use left, respectively
         ++ right, minimal polynomials to decide this question.
 
@@ -901,8 +898,8 @@ FiniteRankNonAssociativeAlgebra(R : CommutativeRing):
 ++ AMS Classifications:
 ++ Keywords: nonassociative algebra, basis
 ++ Reference:
-++  R.D. Schafer: An Introduction to Nonassociative Algebras
-++  Academic Press, New York, 1966
+++   R.D. Schafer: An Introduction to Nonassociative Algebras
+++   Academic Press, New York, 1966
 ++ Description:
 ++   FramedNonAssociativeAlgebra(R) is a
 ++   \spadtype{FiniteRankNonAssociativeAlgebra} (i.e. a non associative
@@ -912,68 +909,62 @@ FramedNonAssociativeAlgebra(R : CommutativeRing): Category ==
       Join(FiniteRankNonAssociativeAlgebra(R), FramedModule(R)) with
   --operations
     elt : (%, Integer) -> R
-      ++ elt(a, i) returns the i-th coefficient of \spad{a} with respect to the
+      ++ \spad{elt(a, i)} returns the \spad{i}-th coefficient of \spad{a} with respect to the
       ++ fixed \spad{R}-module basis.
     structuralConstants : () -> Vector Matrix R
-      ++ structuralConstants() calculates the structural constants
-      ++ \spad{[(gammaijk) for k in 1..rank()]} defined by
+      ++ \spad{structuralConstants()} calculates the structural constants
+      ++ \spad{[(gammaijk) for k in 1 .. rank()]} defined by
       ++ \spad{vi * vj = gammaij1 * v1 + ... + gammaijn * vn},
       ++ where \spad{v1}, ..., \spad{vn} is the fixed \spad{R}-module basis.
     conditionsForIdempotents : () -> List Polynomial R
-      ++ conditionsForIdempotents() determines a complete list
+      ++ \spad{conditionsForIdempotents()} determines a complete list
       ++ of polynomial equations for the coefficients of idempotents
       ++ with respect to the fixed \spad{R}-module basis.
     leftDiscriminant : () -> R
-      ++ leftDiscriminant() returns the
-      ++ determinant of the \spad{n}-by-\spad{n}
+      ++ \spad{leftDiscriminant()} returns the determinant of the \spad{n}-by-\spad{n}
       ++ matrix whose element at the \spad{i}-th row and \spad{j}-th column is
-      ++ given by the left trace of the product \spad{vi*vj}, where
-      ++ \spad{v1}, ..., \spad{vn} are the
-      ++ elements of the fixed \spad{R}-module basis.
+      ++ given by the left trace of the product \spad{vi * vj}, where
+      ++ \spad{v1}, ..., \spad{vn} are the elements of the fixed \spad{R}-module basis.
       ++ Note: the same as \spad{determinant(leftTraceMatrix())}.
     rightDiscriminant : () -> R
-      ++ rightDiscriminant() returns the determinant of the \spad{n}-by-\spad{n}
+      ++ \spad{rightDiscriminant()} returns the determinant of the \spad{n}-by-\spad{n}
       ++ matrix whose element at the \spad{i}-th row and \spad{j}-th column is
-      ++ given by the right trace of the product \spad{vi*vj}, where
-      ++ \spad{v1}, ..., \spad{vn} are the elements of
-      ++ the fixed \spad{R}-module basis.
+      ++ given by the right trace of the product \spad{vi * vj}, where
+      ++ \spad{v1}, ..., \spad{vn} are the elements of the fixed \spad{R}-module basis.
       ++ Note: the same as \spad{determinant(rightTraceMatrix())}.
     leftTraceMatrix : () -> Matrix R
-      ++ leftTraceMatrix() is the \spad{n}-by-\spad{n}
+      ++ \spad{leftTraceMatrix()} is the \spad{n}-by-\spad{n}
       ++ matrix whose element at the \spad{i}-th row and \spad{j}-th column is
-      ++ given by left trace of the product \spad{vi*vj},
-      ++ where \spad{v1}, ..., \spad{vn} are the
-      ++ elements of the fixed \spad{R}-module
+      ++ given by left trace of the product \spad{vi * vj},
+      ++ where \spad{v1}, ..., \spad{vn} are the elements of the fixed \spad{R}-module
       ++ basis.
     rightTraceMatrix : () -> Matrix R
-      ++ rightTraceMatrix() is the \spad{n}-by-\spad{n}
+      ++ \spad{rightTraceMatrix()} is the \spad{n}-by-\spad{n}
       ++ matrix whose element at the \spad{i}-th row and \spad{j}-th column is
-      ++ given by the right trace of the product \spad{vi*vj}, where
+      ++ given by the right trace of the product \spad{vi * vj}, where
       ++ \spad{v1}, ..., \spad{vn} are the elements
       ++ of the fixed \spad{R}-module basis.
     leftRegularRepresentation : % -> Matrix R
-      ++ leftRegularRepresentation(a) returns the matrix of the linear
+      ++ \spad{leftRegularRepresentation(a)} returns the matrix of the linear
       ++ map defined by left multiplication by \spad{a} with respect
       ++ to the fixed \spad{R}-module basis.
     rightRegularRepresentation : % -> Matrix R
-      ++ rightRegularRepresentation(a) returns the matrix of the linear
+      ++ \spad{rightRegularRepresentation(a)} returns the matrix of the linear
       ++ map defined by right multiplication by \spad{a} with respect
       ++ to the fixed \spad{R}-module basis.
     if R has Field then
       leftRankPolynomial : () -> SparseUnivariatePolynomial Polynomial R
-        ++ leftRankPolynomial() calculates the left minimal polynomial
-        ++ of the generic element in the algebra,
-        ++ defined by the same structural
+        ++ \spad{leftRankPolynomial()} calculates the left minimal polynomial
+        ++ of the generic element in the algebra, defined by the same structural
         ++ constants over the polynomial ring in symbolic coefficients with
         ++ respect to the fixed basis.
       rightRankPolynomial : () -> SparseUnivariatePolynomial Polynomial R
-        ++ rightRankPolynomial() calculates the right minimal polynomial
-        ++ of the generic element in the algebra,
-        ++ defined by the same structural
+        ++ \spad{rightRankPolynomial()} calculates the right minimal polynomial
+        ++ of the generic element in the algebra, defined by the same structural
         ++ constants over the polynomial ring in symbolic coefficients with
         ++ respect to the fixed basis.
     apply : (Matrix R, %) -> %
-      ++ apply(m, a) defines a left operation of n by n matrices
+      ++ \spad{apply(m, a)} defines a left operation of n by n matrices
       ++ where n is the rank of the algebra in terms of matrix-vector
       ++ multiplication, this is a substitute for a left module structure.
       ++ Error: if shape of matrix doesn't fit.

--- a/src/algebra/naalgc.spad
+++ b/src/algebra/naalgc.spad
@@ -13,19 +13,19 @@
 ++  with a binary operation.
 Magma() : Category == SetCategory with
     --operations
-      "*": (%,%) -> %
-        ++ a*b is the product of \spad{a} and b in a set with
+      "*": (%, %) -> %
+        ++ \spad{a * b} is the product of \spad{a} and \spad{b} in a set with
         ++ a binary operation.
       rightPower : (%, PositiveInteger) -> %
-        ++ rightPower(a, n) returns the \spad{n}-th right power of \spad{a},
-        ++ i.e. \spad{rightPower(a, n) := rightPower(a, n-1) * a} and
+        ++ \spad{rightPower(a, n)} returns the \spad{n}-th right power of \spad{a},
+        ++ i.e. \spad{rightPower(a, n) := rightPower(a, n - 1) * a} and
         ++ \spad{rightPower(a, 1) := a}.
       leftPower : (%, PositiveInteger) -> %
-        ++ leftPower(a, n) returns the \spad{n}-th left power of \spad{a},
-        ++ i.e. \spad{leftPower(a, n) := a * leftPower(a, n-1)} and
+        ++ \spad{leftPower(a, n)} returns the \spad{n}-th left power of \spad{a},
+        ++ i.e. \spad{leftPower(a, n) := a * leftPower(a, n - 1)} and
         ++ \spad{leftPower(a, 1) := a}.
-      "^": (%,PositiveInteger) -> %
-        ++ a^n returns the \spad{n}-th power of \spad{a},
+      "^": (%, PositiveInteger) -> %
+        ++ \spad{a ^ n} returns the \spad{n}-th power of \spad{a},
         ++ defined by repeated squaring.
     add
       import from RepeatedSquaring(%)
@@ -56,40 +56,41 @@ Magma() : Category == SetCategory with
 ++  MagmaWithUnit is the class of multiplicative monads with unit,
 ++  i.e. sets with a binary operation and a unit element.
 ++ Axioms
-++    leftIdentity("*":(%,%)->%,1)   \tab{30} 1*x=x
-++    rightIdentity("*":(%,%)->%,1)  \tab{30} x*1=x
+++    leftIdentity("*" : (%, %) -> %, 1)   \tab{30} 1 * x = x
+++    rightIdentity("*" : (%, %) -> %, 1)  \tab{30} x * 1 = x
 ++ Common Additional Axioms
 ++    unitsKnown---if "recip" says "failed", that PROVES input wasn't a unit
 MagmaWithUnit() : Category == Magma with
     --constants
       1 : constant ->  %
-        ++ 1 returns the unit element, denoted by 1.
-      sample : constant -> %               ++ sample yields a value of type %
+        ++ \spad{1} returns the unit element, denoted by \spad{1}.
+      sample : constant -> %               
+        ++ \spad{sample} yields a value of type \spadtype{%}
     --operations
       one? : % -> Boolean
-        ++ one?(a) tests whether \spad{a} is the unit 1.
+        ++ \spad{one?(a)} tests whether \spad{a} is the unit \spad{1}.
       rightPower : (%, NonNegativeInteger) -> %
-        ++ rightPower(a, n) returns the \spad{n}-th right power of \spad{a},
-        ++ i.e. \spad{rightPower(a, n) := rightPower(a, n-1) * a} and
+        ++ \spad{rightPower(a, n)} returns the \spad{n}-th right power of \spad{a},
+        ++ i.e. \spad{rightPower(a, n) := rightPower(a, n - 1) * a} and
         ++ \spad{rightPower(a, 0) := 1}.
       leftPower : (%, NonNegativeInteger) -> %
-        ++ leftPower(a, n) returns the \spad{n}-th left power of \spad{a},
-        ++ i.e. \spad{leftPower(a, n) := a * leftPower(a, n-1)} and
+        ++ \spad{leftPower(a, n)} returns the \spad{n}-th left power of \spad{a},
+        ++ i.e. \spad{leftPower(a, n) := a * leftPower(a, n - 1)} and
         ++ \spad{leftPower(a, 0) := 1}.
-      "^": (%,NonNegativeInteger) -> %
-        ++ \spad{a^n} returns the \spad{n}-th power of \spad{a},
+      "^": (%, NonNegativeInteger) -> %
+        ++ \spad{a ^ n} returns the \spad{n}-th power of \spad{a},
         ++ defined by repeated squaring.
-      recip : % -> Union(%,"failed")
-        ++ recip(a) returns an element, which is both a left and a right
+      recip : % -> Union(%, "failed")
+        ++ \spad{recip(a)} returns an element, which is both a left and a right
         ++ inverse of \spad{a},
         ++ or \spad{"failed"} if such an element doesn't exist or cannot
         ++ be determined (see unitsKnown).
-      leftRecip : % -> Union(%,"failed")
-        ++ leftRecip(a) returns an element, which is a left inverse of \spad{a},
+      leftRecip : % -> Union(%, "failed")
+        ++ \spad{leftRecip(a)} returns an element, which is a left inverse of \spad{a},
         ++ or \spad{"failed"} if such an element doesn't exist or cannot
         ++ be determined (see unitsKnown).
-      rightRecip : % -> Union(%,"failed")
-        ++ rightRecip(a) returns an element, which is a right inverse of
+      rightRecip : % -> Union(%, "failed")
+        ++ \spad{rightRecip(a)} returns an element, which is a right inverse of
         ++ \spad{a}, or \spad{"failed"} if such an element doesn't exist
         ++ or cannot be determined (see unitsKnown).
     add

--- a/src/algebra/naalgc.spad
+++ b/src/algebra/naalgc.spad
@@ -128,7 +128,7 @@ MagmaWithUnit() : Category == Magma with
 ++  not necessarily commutative, and not necessarily with a 1.
 NonAssociativeSemiRng() : Category == Join(AbelianSemiGroup, Magma) with
     antiCommutator : (%, %) -> %
-      ++ antiCommutator(a, b) returns \spad{a*b+b*a}.
+      ++ \spad{antiCommutator(a, b)} returns \spad{a * b + b * a}.
   add
     antiCommutator(x, y) == x*y + y*x
 
@@ -154,19 +154,19 @@ NonAssociativeSemiRing() : Category == Join(NonAssociativeSemiRng,
 ++  NonAssociativeRng is a basic ring-type structure, not necessarily
 ++  commutative or associative, and not necessarily with unit.
 ++  Axioms
-++    x*(y+z) = x*y + x*z
-++    (x+y)*z = x*z + y*z
+++    x * (y + z) = x * y + x * z
+++    (x + y) * z = x * z + y * z
 ++  Common Additional Axioms
-++    noZeroDivisors  ab = 0 => a=0 or b=0
+++    noZeroDivisors  a b = 0 => a = 0 or b = 0
 NonAssociativeRng() : Category == Join(NonAssociativeSemiRng,
                                        AbelianGroup)  with
     associator : (%, %, %) -> %
-      ++ associator(a, b, c) returns \spad{(a*b)*c-a*(b*c)}.
+      ++ \spad{associator(a, b, c)} returns \spad{(a * b) * c - a * (b * c)}.
     commutator : (%, %) -> %
-      ++ commutator(a, b) returns \spad{a*b-b*a}.
+      ++ \spad{commutator(a, b)} returns \spad{a * b - b * a}.
   add
-    associator(x, y, z) == (x*y)*z - x*(y*z)
-    commutator(x, y) == x*y - y*x
+    associator(x, y, z) == (x * y) * z - x * (y * z)
+    commutator(x, y) == x * y - y * x
 
 )abbrev category NARING NonAssociativeRing
 ++ Author: J. Grabmeier, R. Wisbauer
@@ -185,10 +185,10 @@ NonAssociativeRing() : Category == Join(NonAssociativeRng,
                                         NonAssociativeSemiRing) with
     --operations
       characteristic : -> NonNegativeInteger
-        ++ characteristic() returns the characteristic of the ring.
+        ++ \spad{characteristic()} returns the characteristic of the ring.
         --we can not make this a constant, since some domains are mutable
       coerce : Integer -> %
-        ++ coerce(n) coerces the integer n to an element of the ring.
+        ++ \spad{coerce(n)} coerces the integer \spad{n} to an element of the ring.
    add
       n : Integer
       coerce(n) == n * 1$%


### PR DESCRIPTION
Update the displayable documentation for categories Magma and MagmaWithUnit for more consistent user display.

Alter spacing on some of the export definition for easier readability.