### PR TITLE
Update fricas-lisp.lisp: sb-alien::int => sb-alien::integer (sb-alien::int is a (signed-byte 32))

### DIFF
--- a/src/lisp/fricas-lisp.lisp
+++ b/src/lisp/fricas-lisp.lisp
@@ -447,7 +447,7 @@ with this hack and will try to convince the GCL crowd to fix this.
 (eval-when (:compile-toplevel :load-toplevel :execute)
 
 (setf *c-type-to-ffi* '(
-    (int SB-ALIEN::int)
+    (int SB-ALIEN::integer)
     (c-string SB-ALIEN::c-string)
     (double SB-ALIEN::double)
     (char-* (sb-alien:* sb-alien:char))


### PR DESCRIPTION
sb-alien::int was signalled by sbcl-2.5.0 on my FriCAS copy as a (signed-byte 32) whereas I was using most-positive-fixnum which is for sb-alien sb-alien:integer. That solved my issue, but of course if you are expecting a 32bit C int this proposal can be deleted.