### PR TITLE
Fix setchildren! not implemented for BinaryRecursiveAggregate

### DIFF
--- a/src/algebra/aggcat.spad
+++ b/src/algebra/aggcat.spad
@@ -1248,6 +1248,12 @@ BinaryRecursiveAggregate(S : Type) : Category == RecursiveAggregate S with
        setelt!(x, "left", b)  == setleft!(x, b)
        setelt!(x, "right", b) == setright!(x, b)
 
+       setchildren!(x, ls) ==
+           #ls ~= 2 => error "a binary tree needs 2 children"
+           setleft!(x, ls.1)
+           setright!(x, ls.2)
+           x
+
 )abbrev category DLAGG DoublyLinkedAggregate
 ++ Author: Michael Monagan; revised by Manuel Bronstein and Richard Jenks
 ++ Date Created: August 87 through August 88


### PR DESCRIPTION
The BinaryRecursiveAggregate extends RecursiveAggregate. However setchildren! is not implemented (nor is it by any of the domains). The proposed fix is to have a default implementation that changes both children. 