### PR TITLE
introduce string join with separator

### DIFF
--- a/src/algebra/aggcat.spad
+++ b/src/algebra/aggcat.spad
@@ -2597,6 +2597,10 @@ StringAggregate : Category == OneDimensionalArrayAggregate Character with
       ++ elt(s, t) returns the concatenation of s and t. It is provided to
       ++ allow juxtaposition of strings to work as concatenation.
       ++ For example, \spad{"smoo" "shed"} returns \spad{"smooshed"}.
+    join: (%, List %) -> %
+      ++ join(sep,ls) returns an element that is the concatenation
+      ++ of all strings in ls but separated by sep, for example,
+      ++ concat("/",["a","b","c"]) returns "a/b/c".
  add
    trim(s : %, cc : CharacterClass) == leftTrim(rightTrim(s, cc), cc)
 

--- a/src/algebra/string.spad
+++ b/src/algebra/string.spad
@@ -374,6 +374,16 @@ IndexedString(mn : Integer) : Export == Implementation where
         RPLACSTR(y, s, m, x, 0, m)$Lisp
         y
 
+    join(sep: %, l: List %): % ==
+        empty? l => empty()
+        lensep := #sep
+        t := new(+/[#s for s in l] + #rest(l)*lensep, space$C)
+        t := copyInto!(t, first l, 1); i := 1 + #first(l)
+        for s in rest l repeat
+            t := copyInto!(t, sep, i); i := i + lensep
+            t := copyInto!(t, s,   i); i := i + #s
+        t
+
     qelt(s : %, i : I) == Qelt(s, i - mn)
 
     elt(s : %, i : I) ==


### PR DESCRIPTION
I think such a function would be quite useful.

join(["a","b","cd"], " + ") returns "a + b + cd"

The question is whether it should live directly in IndexedString (or String) or whether we introduce a new package StringTools where (maybe) also other useful string functions can go.