### PR TITLE
Make fricas installation relocatable

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -154,6 +154,10 @@ install-src:
 	echo FRICAS_VERSION='"${PACKAGE_VERSION}"' >> '${COMMAND}'.tmp
 	echo FRICAS_LISP_FLAVOR='"${FRICAS_LISP_FLAVOR}"' >> '${COMMAND}'.tmp
 	echo FRICAS_LISP_VERSION='"${FRICAS_LISP_VERSION}"' >> '${COMMAND}'.tmp
+	if [ ${FRICAS_LISP_FLAVOR} = ecl -a -z "$$ECLDIR" ]; then \
+	    echo 'ECLDIR=$$(ecl --eval "(princ (si:get-library-pathname))" --eval "(quit)")' >> '${COMMAND}'.tmp ; \
+	    echo '[ -n "$$ECLDIR" ] && export ECLDIR' >> '${COMMAND}'.tmp ; \
+	fi
 	cat $(fricas_src_srcdir)/etc/fricas >> '${COMMAND}'.tmp
 	$(INSTALL_SCRIPT) '${COMMAND}'.tmp '${COMMAND}'
 	-rm '${COMMAND}'.tmp

--- a/Makefile.in
+++ b/Makefile.in
@@ -138,8 +138,11 @@ install-src:
 	     || exit 1 ; \
 	done
 	echo '#!/bin/sh -' > '${COMMAND}'.tmp
-	echo exec_prefix='"$${FRICAS_PREFIX:-$(exec_prefix)}"' \
-               >> '${COMMAND}'.tmp
+	cat $(fricas_src_srcdir)/etc/resolvelinks.sh >> '${COMMAND}'.tmp
+	echo 'exec_prefix=$$(resolvelinks "$$0")' >> '${COMMAND}'.tmp
+	echo 'exec_prefix=$${exec_prefix%/*}'  >> '${COMMAND}'.tmp
+	echo 'exec_prefix=$${exec_prefix%/*}'  >> '${COMMAND}'.tmp
+	echo 'exec_prefix=$$(cd $$exec_prefix && pwd -P)' >> '${COMMAND}'.tmp
 	if test "$(fricas_lib)" != "$(libdir)" ;  then echo \
             FRICAS='"$${exec_prefix}/$(fricas_lib)/fricas/target/$(target)"' \
               >> '${COMMAND}'.tmp ; \

--- a/src/etc/resolvelinks.sh
+++ b/src/etc/resolvelinks.sh
@@ -1,0 +1,79 @@
+# Taken from https://github.com/passagemath/passagemath/blob/main/sage#L29
+#
+# Resolve all symbolic links in a filename.  This more or less behaves
+# like "readlink -f" except that it does not convert the filename to an
+# absolute path (a relative path remains relative), nor does it treat
+# "." or ".." specially.
+resolvelinks() {
+    # $in is what still needs to be converted (normally has no starting slash)
+    in="$1"
+    # $out is the part which is converted (normally ends with trailing slash)
+    out="./"
+
+    # Move stuff from $in to $out
+    while [ -n "$in" ]; do
+        # Normalize $in by replacing consecutive slashes by one slash
+        in=$(echo "${in}" | sed 's://*:/:g')
+
+        # If $in starts with a slash, remove it and set $out to the root
+        in_without_slash=${in#/}
+        if [ "$in" != "$in_without_slash" ]; then
+            in=$in_without_slash
+            out="/"
+            continue
+        fi
+
+        # Check that the directory $out exists by trying to cd to it.
+        # If this fails, then cd will show an error message (unlike
+        # test -d "$out"), so no need to be more verbose.
+        ( cd "$out" ) || return $?
+
+
+        # Get the first component of $in
+        f=${in%%/*}
+
+        # If it is not a symbolic link, simply move it to $out
+        if [ ! -L "$out$f" ]; then
+            in=${in#"$f"}
+            out="$out$f"
+
+            # If the new $in starts with a slash, move it to $out
+            in_without_slash=${in#/}
+            if [ "$in" != "$in_without_slash" ]; then
+                in=$in_without_slash
+                out="$out/"
+            fi
+            continue
+        fi
+
+        # Now resolve the symbolic link "$f"
+        f_resolved=`readlink -n "$out$f" 2>/dev/null`
+        status=$?
+        # status 127 means readlink could not be found.
+        if [ $status -eq 127 ]; then
+            # We don't have "readlink", try a stupid "ls" hack instead.
+            # This will fail if we have filenames like "a -> b".
+            fls=`ls -l "$out$f" 2>/dev/null`
+            status=$?
+            f_resolved=${fls##*-> }
+
+            # If $fls equals $f_resolved, then certainly
+            # something is wrong
+            if [ $status -eq 0 -a "$fls" = "$f_resolved" ]; then
+                echo >&2 "Cannot parse output from ls -l '$out$f'"
+                return 1
+            fi
+        fi
+        if [ $status -ne 0 ]; then
+            echo >&2 "Cannot read symbolic link '$out$f'"
+            return $status
+        fi
+
+        # In $in, replace $f by $f_resolved (leave $out alone)
+        in="${in#${f}}"
+        in="${f_resolved}${in}"
+    done
+
+    # Return $out
+    echo "$out"
+}


### PR DESCRIPTION
Instead of hard-coding the `exec_prefix` in the installed `fricas` script, obtain it from the invocation of the script.

The portable shell code for this also handles the situation when the script is invoked via symlinks.
