### PR TITLE
Typo in generic.spad

### DIFF
--- a/src/algebra/generic.spad
+++ b/src/algebra/generic.spad
@@ -69,7 +69,7 @@ GenericNonAssociativeAlgebra(R : CommutativeRing, n : PositiveInteger, _
         ++ of the generic element
       genericLeftMinimalPolynomial : % -> SUP(FPR)
         ++ genericLeftMinimalPolynomial(a) substitutes the coefficients
-        ++ of {em a} for the generic coefficients in
+        ++ of {\em a} for the generic coefficients in
         ++ \spad{leftRankPolynomial()}
       genericLeftTrace : % -> FPR
         ++ genericLeftTrace(a) substitutes the coefficients


### PR DESCRIPTION
{em a} -> {\em a}