### PR TITLE
WM_DELETE_WINDOW support for hypertex

### DIFF
--- a/src/hyper/event.c
+++ b/src/hyper/event.c
@@ -180,6 +180,11 @@ handle_event(XEvent * event)
       case DestroyNotify:
 /*        fprintf(stderr,"event:handle_event type=DestroyNotify\n");*/
         break;
+      case ClientMessage:
+        if (event->xclient.message_type == gxa_wm_protocols
+            && event->xclient.data.l[0] == gxa_wm_delete_window)
+            quitHyperDoc();
+        break;
       case Expose:
 /*        fprintf(stderr,"event:handle_event type=Expose\n");*/
         XGetWindowAttributes(gXDisplay, gWindow->fMainWindow, &wa);

--- a/src/hyper/hyper.c
+++ b/src/hyper/hyper.c
@@ -77,6 +77,7 @@ int MenuServerOpened = 1;
 /* X11 display and screen variables */
 
 Display *gXDisplay;
+Atom gxa_wm_protocols, gxa_wm_delete_window;
 int      gXScreenNumber;
 
 /*

--- a/src/hyper/hyper.h
+++ b/src/hyper/hyper.h
@@ -398,6 +398,7 @@ extern HyperLink *quitLink; /** a special link to the protected quit page **/
 /* From hyper.c */
 extern int      gXScreenNumber;
 extern Display *gXDisplay;
+extern Atom gxa_wm_protocols, gxa_wm_delete_window;
 extern int gSwitch_to_mono;
 extern unsigned long * spadColors;
 extern int gIsEndOfOutput;

--- a/src/hyper/initx.c
+++ b/src/hyper/initx.c
@@ -47,6 +47,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unistd.h>
 #include <sys/signal.h>
 #include <setjmp.h>
+#include <X11/Xlib.h>
 #include <X11/cursorfont.h>
 #include <X11/Xresource.h>
 #include <X11/Xatom.h>
@@ -133,6 +134,8 @@ initializeWindowSystem(void)
         fprintf(stderr, "(HyperDoc) Cannot connect to the X11 server!\n");
         exit(-1);
     }
+    gxa_wm_protocols = XInternAtom(gXDisplay, "WM_PROTOCOLS", False);
+    gxa_wm_delete_window = XInternAtom(gXDisplay, "WM_DELETE_WINDOW", False);
 
     /* Get the screen */
 /*    fprintf(stderr,"initx:initializeWindowSystem:DefaultScreen\n");*/
@@ -470,6 +473,7 @@ open_window(Window w)
                                     x, y, width, height, gWindow->border_width,
                                     gBorderColor,
                                     WhitePixel(gXDisplay, gXScreenNumber));
+    XSetWMProtocols(gXDisplay, gWindow->fMainWindow, &gxa_wm_delete_window, 1);
 
     gWindow->fScrollWindow = XCreateSimpleWindow(gXDisplay, gWindow->fMainWindow,
                                          1, 1, 1, 1, 0,


### PR DESCRIPTION
Makes close buttons provided by the window manager work properly. Some WMs kill clients instead if they don't support the protocol.