### PR TITLE
doc: do not build the viewports in parallel

### DIFF
--- a/src/doc/Makefile.in
+++ b/src/doc/Makefile.in
@@ -320,6 +320,12 @@ VIEWPORTNAMESviewports = ${VIEWPORTFILES}
 # files in ${GEN_VIEWPORTFILES_PHT} involve the generation of
 # graphics, the files in ${GEN_NONVIEWPORTFILES_PHT} do not.
 GEN_VIEWPORTFILES_PHT = ${patsubst %, %.pht, ${VIEWPORTNAMES${MAYBE_VIEWPORTS}}}
+
+# Each of these runs its own sman, which serves sockets under the fixed
+# names /tmp/.i<n> and /tmp/.h<n> and sweeps /tmp for stale ones at startup,
+# so two at once can tread on each other.  GNU make 4.4 and later restrict
+# this to the named targets, older make serialises the whole file.
+.NOTPARALLEL: ${GEN_VIEWPORTFILES_PHT}
 GEN_NONVIEWPORTFILES_PHT = ${patsubst %, %.pht, \
     ${filter-out ${VIEWPORTFILES}, ${HT_PASTEFILES} ${HTEX_PASTEFILES}}}
 


### PR DESCRIPTION
Each `GEN_VIEWPORTFILES_PHT` target runs its own `sman`. `sman` serves its
sockets under the fixed names `/tmp/.i<n>` and `/tmp/.h<n>`
(`src/include/com.h:107`) and sweeps `/tmp` for stale ones when it starts
(`src/sman/sman.c:372`), so two of them running at the same time can unlink
each other's live sockets.

A parallel make does start two: on this machine the process list showed
`-paste ug01.ht` and `-paste ug10.ht` running together, each with its own
`hypertex` and `viewman`.

GNU make 4.4 and later apply `.NOTPARALLEL` with prerequisites to just those
targets, so the rest of `src/doc` still builds in parallel; older make
serialises the whole file, which is slower but also correct.

Verified on x86-64 Fedora 44, GNU make 4.4.1, SBCL 2.6.8: with this change the
process list never holds more than one `.ht` at a time, and `make check`
reports `no unexpected failures` across five consecutive clean-chroot builds.

This is not a fix for #221 — I checked, the hang described there still happens
with the viewports serialised — but the two are independent and this one stands
on its own.
